### PR TITLE
fix switch to main document

### DIFF
--- a/lib/WebDriverTargetLocator.php
+++ b/lib/WebDriverTargetLocator.php
@@ -33,7 +33,8 @@ class WebDriverTargetLocator {
    * @return WebDriver The driver focused on the top window or the first frame.
    */
   public function defaultContent() {
-    $this->executor->execute(DriverCommand::SWITCH_TO_FRAME, array());
+    $params = array('id' => null);
+    $this->executor->execute(DriverCommand::SWITCH_TO_FRAME, $params);
 
     return $this->driver;
   }


### PR DESCRIPTION
Hi,

For a while, I didn't think about the library which didn't send the id parameter because it was working for Firefox, Chrome and a lot of other drivers.

However, some others required this parameter : 
* https://code.google.com/p/chromedriver/issues/detail?id=981
* https://github.com/selendroid/selendroid/issues/664
* https://github.com/operasoftware/operachromiumdriver/issues/2

In fact, we must send a NULL parameter to fix it, just like the java client do : 
https://code.google.com/p/selenium/source/browse/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java#886

and it is supported by the protocol : 
https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/frame

With this new parameter, no regression has been detected for FF, Chrome, HTMLunit, PhantomJS, IE (11).
And it fix the issues above for other drivers.

Thanks