### PR TITLE
RemoteWebDriver: Allow specifying request timeout

### DIFF
--- a/lib/chrome/ChromeDriver.php
+++ b/lib/chrome/ChromeDriver.php
@@ -47,7 +47,8 @@ class ChromeDriver extends RemoteWebDriver {
   public static function create(
     $url = 'http://localhost:4444/wd/hub',
     $desired_capabilities = null,
-    $timeout_in_ms = 300000
+    $timeout_in_ms = 300000,
+    $request_timeout_in_ms = 300000
   ) {
     throw new WebDriverException('Please use ChromeDriver::start() instead.');
   }

--- a/lib/remote/RemoteWebDriver.php
+++ b/lib/remote/RemoteWebDriver.php
@@ -47,12 +47,14 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor {
    * @param string $url The url of the remote server
    * @param DesiredCapabilities $desired_capabilities The desired capabilities
    * @param int $connection_timeout_in_ms
+   * @param int $request_timeout_in_ms
    * @return RemoteWebDriver
    */
   public static function create(
     $url = 'http://localhost:4444/wd/hub',
     $desired_capabilities = null,
-    $connection_timeout_in_ms = 300000
+    $connection_timeout_in_ms = 300000,
+    $request_timeout_in_ms = 300000
   ) {
     $url = preg_replace('#/+$#', '', $url);
 
@@ -64,6 +66,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor {
 
     $executor = new HttpCommandExecutor($url);
     $executor->setConnectionTimeout($connection_timeout_in_ms);
+    $executor->setRequestTimeout($request_timeout_in_ms);
 
     $command = new WebDriverCommand(
       null,


### PR DESCRIPTION
Previously you could only set the request timeout after the first
request (NEW_SESSION) was sent. If you want to alter the timeout, you
presumably want to affect the first request too.