### PR TITLE
Correct curl value for CURLOPT_TIMEOUT_MS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "source": "https://github.com/facebook/php-webdriver"
   },
   "require": {
-    "php": ">=5.3.3"
+    "php": ">=5.3.19"
   },
   "require-dev": {
     "phpunit/phpunit": "3.7.*",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "source": "https://github.com/facebook/php-webdriver"
   },
   "require": {
-    "php": ">=5.3.19"
+    "php": ">=5.3.3"
   },
   "require-dev": {
     "phpunit/phpunit": "3.7.*",

--- a/lib/remote/HttpCommandExecutor.php
+++ b/lib/remote/HttpCommandExecutor.php
@@ -161,7 +161,11 @@ class HttpCommandExecutor implements WebDriverCommandExecutor {
    * @return HttpCommandExecutor
    */
   public function setRequestTimeout($timeout_in_ms) {
-    curl_setopt($this->curl, CURLOPT_TIMEOUT_MS, $timeout_in_ms);
+    curl_setopt(
+      $this->curl, 
+      /*CURLOPT_TIMEOUT_MS*/ 155, 
+      $timeout_in_ms
+    );
     return $this;
   }
 


### PR DESCRIPTION
Our version of PHP (5.3.3) was giving an expects 'long' not string error. I know this is an officially unsupported version. We're locked in by our shared platform. 

This is more for reference.