### PR TITLE
Fixed strpos: ending parentheses is in incorrect location

### DIFF
--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -259,7 +259,7 @@ class WebDriverSelect {
    * @return string The escaped string.
    */
   protected function escapeQuotes($to_escape) {
-    if (strpos($to_escape, '"') !== false && strpos($to_escape, "'" != false)) {
+    if (strpos($to_escape, '"') !== false && strpos($to_escape, "'") !== false) {
       $substrings = explode('"', $to_escape);
 
       $escaped = "concat(";
@@ -274,7 +274,7 @@ class WebDriverSelect {
       return $escaped;
     }
 
-    if (strpos($to_escape, '"' !== false)) {
+    if (strpos($to_escape, '"') !== false) {
       return sprintf("'%s'", $to_escape);
     }
 


### PR DESCRIPTION
Fixed the current implementation of strpos, it currently looked like this

 `strpos($to_escape, "'" != false))` incorrectly passes `"'" != false` as the second argument.

Changed it to `if (strpos($to_escape, '"') !== false && strpos($to_escape, "'") !== false) {`