### PR TITLE
Resolved conflicts with other packages like Phing regarding Exception classes.

### DIFF
--- a/lib/WebDriverExceptions.php
+++ b/lib/WebDriverExceptions.php
@@ -52,113 +52,113 @@ class WebDriverException extends Exception {
         // Success
         break;
       case 1:
-        throw new IndexOutOfBoundsException($message, $results);
+        throw new IndexOutOfBoundsWebDriverException($message, $results);
       case 2:
-        throw new NoCollectionException($message, $results);
+        throw new NoCollectionWebDriverException($message, $results);
       case 3:
-        throw new NoStringException($message, $results);
+        throw new NoStringWebDriverException($message, $results);
       case 4:
-        throw new NoStringLengthException($message, $results);
+        throw new NoStringLengthWebDriverException($message, $results);
       case 5:
-        throw new NoStringWrapperException($message, $results);
+        throw new NoStringWrapperWebDriverException($message, $results);
       case 6:
-        throw new NoSuchDriverException($message, $results);
+        throw new NoSuchDriverWebDriverException($message, $results);
       case 7:
-        throw new NoSuchElementException($message, $results);
+        throw new NoSuchElementWebDriverException($message, $results);
       case 8:
-        throw new NoSuchFrameException($message, $results);
+        throw new NoSuchFrameWebDriverException($message, $results);
       case 9:
-        throw new UnknownCommandException($message, $results);
+        throw new UnknownCommandWebDriverException($message, $results);
       case 10:
-        throw new StaleElementReferenceException($message, $results);
+        throw new StaleElementReferenceWebDriverException($message, $results);
       case 11:
-        throw new ElementNotVisibleException($message, $results);
+        throw new ElementNotVisibleWebDriverException($message, $results);
       case 12:
-        throw new InvalidElementStateException($message, $results);
+        throw new InvalidElementStateWebDriverException($message, $results);
       case 13:
-        throw new UnknownServerException($message, $results);
+        throw new UnknownServerWebDriverException($message, $results);
       case 14:
-        throw new ExpectedException($message, $results);
+        throw new ExpectedWebDriverException($message, $results);
       case 15:
-        throw new ElementNotSelectableException($message, $results);
+        throw new ElementNotSelectableWebDriverException($message, $results);
       case 16:
-        throw new NoSuchDocumentException($message, $results);
+        throw new NoSuchDocumentWebDriverException($message, $results);
       case 17:
-        throw new UnexpectedJavascriptException($message, $results);
+        throw new UnexpectedJavascriptWebDriverException($message, $results);
       case 18:
-        throw new NoScriptResultException($message, $results);
+        throw new NoScriptResultWebDriverException($message, $results);
       case 19:
-        throw new XPathLookupException($message, $results);
+        throw new XPathLookupWebDriverException($message, $results);
       case 20:
-        throw new NoSuchCollectionException($message, $results);
+        throw new NoSuchCollectionWebDriverException($message, $results);
       case 21:
-        throw new TimeOutException($message, $results);
+        throw new TimeOutWebDriverException($message, $results);
       case 22:
-        throw new NullPointerException($message, $results);
+        throw new NullPointerWebDriverException($message, $results);
       case 23:
-        throw new NoSuchWindowException($message, $results);
+        throw new NoSuchWindowWebDriverException($message, $results);
       case 24:
-        throw new InvalidCookieDomainException($message, $results);
+        throw new InvalidCookieDomainWebDriverException($message, $results);
       case 25:
-        throw new UnableToSetCookieException($message, $results);
+        throw new UnableToSetCookieWebDriverException($message, $results);
       case 26:
-        throw new UnexpectedAlertOpenException($message, $results);
+        throw new UnexpectedAlertOpenWebDriverException($message, $results);
       case 27:
-        throw new NoAlertOpenException($message, $results);
+        throw new NoAlertOpenWebDriverException($message, $results);
       case 28:
-        throw new ScriptTimeoutException($message, $results);
+        throw new ScriptTimeoutWebDriverException($message, $results);
       case 29:
-        throw new InvalidCoordinatesException($message, $results);
+        throw new InvalidCoordinatesWebDriverException($message, $results);
       case 30:
-        throw new IMENotAvailableException($message, $results);
+        throw new IMENotAvailableWebDriverException($message, $results);
       case 31:
-        throw new IMEEngineActivationFailedException($message, $results);
+        throw new IMEEngineActivationFailedWebDriverException($message, $results);
       case 32:
-        throw new InvalidSelectorException($message, $results);
+        throw new InvalidSelectorWebDriverException($message, $results);
       case 33:
-        throw new SessionNotCreatedException($message, $results);
+        throw new SessionNotCreatedWebDriverException($message, $results);
       case 34:
-        throw new MoveTargetOutOfBoundsException($message, $results);
+        throw new MoveTargetOutOfBoundsWebDriverException($message, $results);
       default:
         throw new UnrecognizedExceptionException($message, $results);
     }
   }
 }
 
-class IndexOutOfBoundsException extends WebDriverException {} // 1
-class NoCollectionException extends WebDriverException {} // 2
-class NoStringException extends WebDriverException {} // 3
-class NoStringLengthException extends WebDriverException {} // 4
-class NoStringWrapperException extends WebDriverException {} // 5
-class NoSuchDriverException extends WebDriverException {} // 6
-class NoSuchElementException extends WebDriverException {} // 7
-class NoSuchFrameException extends WebDriverException {} // 8
-class UnknownCommandException extends WebDriverException {} // 9
-class StaleElementReferenceException extends WebDriverException {} // 10
-class ElementNotVisibleException extends WebDriverException {} // 11
-class InvalidElementStateException extends WebDriverException {} // 12
-class UnknownServerException extends WebDriverException {} // 13
-class ExpectedException extends WebDriverException {} // 14
-class ElementNotSelectableException extends WebDriverException {} // 15
-class NoSuchDocumentException extends WebDriverException {} // 16
-class UnexpectedJavascriptException extends WebDriverException {} // 17
-class NoScriptResultException extends WebDriverException {} // 18
-class XPathLookupException extends WebDriverException {} // 19
-class NoSuchCollectionException extends WebDriverException {} // 20
-class TimeOutException extends WebDriverException {} // 21
-class NullPointerException extends WebDriverException {} // 22
-class NoSuchWindowException extends WebDriverException {} // 23
-class InvalidCookieDomainException extends WebDriverException {} // 24
-class UnableToSetCookieException extends WebDriverException {} // 25
-class UnexpectedAlertOpenException extends WebDriverException {} // 26
-class NoAlertOpenException extends WebDriverException {} // 27
-class ScriptTimeoutException extends WebDriverException {} // 28
-class InvalidCoordinatesException extends WebDriverException {}// 29
-class IMENotAvailableException extends WebDriverException {} // 30
-class IMEEngineActivationFailedException extends WebDriverException {}// 31
-class InvalidSelectorException extends WebDriverException {} // 32
-class SessionNotCreatedException extends WebDriverException {} // 33
-class MoveTargetOutOfBoundsException extends WebDriverException {} // 34
+class IndexOutOfBoundsWebDriverException extends WebDriverException {} // 1
+class NoCollectionWebDriverException extends WebDriverException {} // 2
+class NoStringWebDriverException extends WebDriverException {} // 3
+class NoStringLengthWebDriverException extends WebDriverException {} // 4
+class NoStringWrapperWebDriverException extends WebDriverException {} // 5
+class NoSuchDriverWebDriverException extends WebDriverException {} // 6
+class NoSuchElementWebDriverException extends WebDriverException {} // 7
+class NoSuchFrameWebDriverException extends WebDriverException {} // 8
+class UnknownCommandWebDriverException extends WebDriverException {} // 9
+class StaleElementReferenceWebDriverException extends WebDriverException {} // 10
+class ElementNotVisibleWebDriverException extends WebDriverException {} // 11
+class InvalidElementStateWebDriverException extends WebDriverException {} // 12
+class UnknownServerWebDriverException extends WebDriverException {} // 13
+class ExpectedWebDriverException extends WebDriverException {} // 14
+class ElementNotSelectableWebDriverException extends WebDriverException {} // 15
+class NoSuchDocumentWebDriverException extends WebDriverException {} // 16
+class UnexpectedJavascriptWebDriverException extends WebDriverException {} // 17
+class NoScriptResultWebDriverException extends WebDriverException {} // 18
+class XPathLookupWebDriverException extends WebDriverException {} // 19
+class NoSuchCollectionWebDriverException extends WebDriverException {} // 20
+class TimeOutWebDriverException extends WebDriverException {} // 21
+class NullPointerWebDriverException extends WebDriverException {} // 22
+class NoSuchWindowWebDriverException extends WebDriverException {} // 23
+class InvalidCookieDomainWebDriverException extends WebDriverException {} // 24
+class UnableToSetCookieWebDriverException extends WebDriverException {} // 25
+class UnexpectedAlertOpenWebDriverException extends WebDriverException {} // 26
+class NoAlertOpenWebDriverException extends WebDriverException {} // 27
+class ScriptTimeoutWebDriverException extends WebDriverException {} // 28
+class InvalidCoordinatesWebDriverException extends WebDriverException {}// 29
+class IMENotAvailableWebDriverException extends WebDriverException {} // 30
+class IMEEngineActivationFailedWebDriverException extends WebDriverException {}// 31
+class InvalidSelectorWebDriverException extends WebDriverException {} // 32
+class SessionNotCreatedWebDriverException extends WebDriverException {} // 33
+class MoveTargetOutOfBoundsWebDriverException extends WebDriverException {} // 34
 
 // Fallback
 class UnrecognizedExceptionException extends WebDriverException {}

--- a/lib/WebDriverExceptions.php
+++ b/lib/WebDriverExceptions.php
@@ -120,7 +120,7 @@ class WebDriverException extends Exception {
       case 34:
         throw new MoveTargetOutOfBoundsWebDriverException($message, $results);
       default:
-        throw new UnrecognizedExceptionException($message, $results);
+        throw new UnrecognizedExceptionWebDriverException($message, $results);
     }
   }
 }
@@ -161,9 +161,9 @@ class SessionNotCreatedWebDriverException extends WebDriverException {} // 33
 class MoveTargetOutOfBoundsWebDriverException extends WebDriverException {} // 34
 
 // Fallback
-class UnrecognizedExceptionException extends WebDriverException {}
+class UnrecognizedExceptionWebDriverException extends WebDriverException {}
 
-class UnexpectedTagNameException extends WebDriverException {
+class UnexpectedTagNameWebDriverException extends WebDriverException {
 
   /**
    * @param string $expected_tag_name
@@ -181,4 +181,4 @@ class UnexpectedTagNameException extends WebDriverException {
   }
 }
 
-class UnsupportedOperationException extends WebDriverException {}
+class UnsupportedOperationWebDriverException extends WebDriverException {}

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -98,7 +98,7 @@ class WebDriverExpectedCondition {
         try {
           $element = $driver->findElement($by);
           return $element->isDisplayed() ? $element : null;
-        } catch (StaleElementReferenceException $e) {
+        } catch (StaleElementReferenceWebDriverException $e) {
           return null;
         }
       }
@@ -154,7 +154,7 @@ class WebDriverExpectedCondition {
         try {
           $element_text = $driver->findElement($by)->getText();
           return strpos($element_text, $text) !== false;
-        } catch (StaleElementReferenceException $e) {
+        } catch (StaleElementReferenceWebDriverException $e) {
           return null;
         }
       }
@@ -176,7 +176,7 @@ class WebDriverExpectedCondition {
         try {
           $element_text = $driver->findElement($by)->getAttribute('value');
           return strpos($element_text, $text) !== false;
-        } catch (StaleElementReferenceException $e) {
+        } catch (StaleElementReferenceWebDriverException $e) {
           return null;
         }
       }
@@ -197,7 +197,7 @@ class WebDriverExpectedCondition {
       function ($driver) use ($frame_locator) {
         try {
           return $driver->switchTo()->frame($frame_locator);
-        } catch (NoSuchFrameException $e) {
+        } catch (NoSuchFrameWebDriverException $e) {
           return false;
         }
       }
@@ -217,9 +217,9 @@ class WebDriverExpectedCondition {
       function ($driver) use ($by) {
         try {
           return !($driver->findElement($by)->isDisplayed());
-        } catch (NoSuchElementException $e) {
+        } catch (NoSuchElementWebDriverException $e) {
           return true;
-        } catch (StaleElementReferenceException $e) {
+        } catch (StaleElementReferenceWebDriverException $e) {
           return true;
         }
       }
@@ -241,9 +241,9 @@ class WebDriverExpectedCondition {
       function ($driver) use ($by, $text) {
         try {
           return !($driver->findElement($by)->getText() === $text);
-        } catch (NoSuchElementException $e) {
+        } catch (NoSuchElementWebDriverException $e) {
           return true;
-        } catch (StaleElementReferenceException $e) {
+        } catch (StaleElementReferenceWebDriverException $e) {
           return true;
         }
       }
@@ -273,7 +273,7 @@ class WebDriverExpectedCondition {
           } else {
             return null;
           }
-        } catch (StaleElementReferenceException $e) {
+        } catch (StaleElementReferenceWebDriverException $e) {
           return null;
         }
       }
@@ -293,7 +293,7 @@ class WebDriverExpectedCondition {
         try {
           $element->isEnabled();
           return false;
-        } catch (StaleElementReferenceException $e) {
+        } catch (StaleElementReferenceWebDriverException $e) {
           return true;
         }
       }
@@ -306,7 +306,7 @@ class WebDriverExpectedCondition {
    * This works around the problem of conditions which have two parts: find an
    * element and then check for some condition on it. For these conditions it is
    * possible that an element is located and then subsequently it is redrawn on
-   * the client. When this happens a StaleElementReferenceException is thrown
+   * the client. When this happens a StaleElementReferenceWebDriverException is thrown
    * when the second part of the condition is checked.
    *
    * @param WebDriverExpectedCondition $condition The condition wrapped.
@@ -318,7 +318,7 @@ class WebDriverExpectedCondition {
       function ($driver) use ($condition) {
         try {
           return call_user_func($condition->getApply(), $driver);
-        } catch (StaleElementReferenceException $e) {
+        } catch (StaleElementReferenceWebDriverException $e) {
           return null;
         }
       }
@@ -361,7 +361,7 @@ class WebDriverExpectedCondition {
           try {
             $element = $driver->findElement($element_or_by);
             return $element->isSelected() === $selected;
-          } catch (StaleElementReferenceException $e) {
+          } catch (StaleElementReferenceWebDriverException $e) {
             return null;
           }
         }
@@ -385,7 +385,7 @@ class WebDriverExpectedCondition {
           $alert = $driver->switchTo()->alert();
           $alert->getText();
           return $alert;
-        } catch (NoAlertOpenException $e) {
+        } catch (NoAlertOpenWebDriverException $e) {
           return null;
         }
       }

--- a/lib/WebDriverSearchContext.php
+++ b/lib/WebDriverSearchContext.php
@@ -24,7 +24,7 @@ interface WebDriverSearchContext {
    * mechanism.
    *
    * @param WebDriverBy $locator
-   * @return WebDriverElement NoSuchElementException is thrown in
+   * @return WebDriverElement NoSuchElementWebDriverException is thrown in
    *    HttpCommandExecutor if no element is found.
    * @see WebDriverBy
    */

--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -72,7 +72,7 @@ class WebDriverSelect {
       }
     }
 
-    throw new NoSuchElementException('No options are selected');
+    throw new NoSuchElementWebDriverException('No options are selected');
   }
 
   /**
@@ -114,7 +114,7 @@ class WebDriverSelect {
       }
     }
     if (!$matched) {
-      throw new NoSuchElementException(
+      throw new NoSuchElementWebDriverException(
         sprintf('Cannot locate option with index: %d', $index)
       );
     }
@@ -145,7 +145,7 @@ class WebDriverSelect {
     }
 
     if (!$matched) {
-      throw new NoSuchElementException(
+      throw new NoSuchElementWebDriverException(
         sprintf('Cannot locate option with value: %s', $value)
       );
     }
@@ -192,7 +192,7 @@ class WebDriverSelect {
     }
 
     if (!$matched) {
-      throw new NoSuchElementException(
+      throw new NoSuchElementWebDriverException(
         sprintf('Cannot locate option with text: %s', $text)
       );
     }

--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -25,7 +25,7 @@ class WebDriverSelect {
     $tag_name = $element->getTagName();
 
     if ($tag_name !== 'select') {
-      throw new UnexpectedTagNameException('select', $tag_name);
+      throw new UnexpectedTagNameWebDriverException('select', $tag_name);
     }
     $this->element = $element;
     $value = $element->getAttribute('multiple');
@@ -82,7 +82,7 @@ class WebDriverSelect {
    */
   public function deselectAll() {
     if (!$this->isMultiple()) {
-      throw new UnsupportedOperationException(
+      throw new UnsupportedOperationWebDriverException(
         'You may only deselect all options of a multi-select'
       );
     }

--- a/lib/WebDriverWait.php
+++ b/lib/WebDriverWait.php
@@ -57,7 +57,7 @@ class WebDriverWait {
         if ($ret_val) {
           return $ret_val;
         }
-      } catch (NoSuchElementException $e) {
+      } catch (NoSuchElementWebDriverException $e) {
         $last_exception = $e;
       }
       usleep($this->interval * 1000);
@@ -66,6 +66,6 @@ class WebDriverWait {
     if ($last_exception) {
       throw $last_exception;
     }
-    throw new TimeOutException($message);
+    throw new TimeOutWebDriverException($message);
   }
 }

--- a/lib/WebDriverWindow.php
+++ b/lib/WebDriverWindow.php
@@ -121,12 +121,12 @@ class WebDriverWindow {
    *
    * @param string $orientation
    * @return WebDriverWindow The instance.
-   * @throws IndexOutOfBoundsException
+   * @throws IndexOutOfBoundsWebDriverException
    */
   public function setScreenOrientation($orientation) {
     $orientation = strtoupper($orientation);
     if (!in_array($orientation, array('PORTRAIT', 'LANDSCAPE'))) {
-      throw new IndexOutOfBoundsException(
+      throw new IndexOutOfBoundsWebDriverException(
         "Orientation must be either PORTRAIT, or LANDSCAPE"
       );
     }

--- a/lib/interactions/internal/WebDriverCoordinates.php
+++ b/lib/interactions/internal/WebDriverCoordinates.php
@@ -40,7 +40,7 @@ class WebDriverCoordinates {
    * @return WebDriverPoint
    */
   public function onScreen() {
-    throw new UnsupportedOperationException(
+    throw new UnsupportedOperationWebDriverException(
       'onScreen is planned but not yet supported by Selenium'
     );
   }

--- a/lib/net/URLChecker.php
+++ b/lib/net/URLChecker.php
@@ -28,7 +28,7 @@ class URLChecker {
       usleep(self::POLL_INTERVAL_MS);
     }
 
-    throw new TimeOutException(sprintf(
+    throw new TimeOutWebDriverException(sprintf(
       "Timed out waiting for %s to become available after %d ms.",
       $url,
       $timeout_in_ms
@@ -45,7 +45,7 @@ class URLChecker {
       usleep(self::POLL_INTERVAL_MS);
     }
 
-    throw new TimeOutException(sprintf(
+    throw new TimeOutWebDriverException(sprintf(
       "Timed out waiting for %s to become unavailable after %d ms.",
       $url,
       $timeout_in_ms

--- a/lib/remote/RemoteWebDriver.php
+++ b/lib/remote/RemoteWebDriver.php
@@ -122,7 +122,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor {
    * Find the first WebDriverElement using the given mechanism.
    *
    * @param WebDriverBy $by
-   * @return RemoteWebElement NoSuchElementException is thrown in
+   * @return RemoteWebElement NoSuchElementWebDriverException is thrown in
    *    HttpCommandExecutor if no element is found.
    * @see WebDriverBy
    */

--- a/lib/remote/RemoteWebElement.php
+++ b/lib/remote/RemoteWebElement.php
@@ -73,7 +73,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable {
    * mechanism.
    *
    * @param WebDriverBy $by
-   * @return RemoteWebElement NoSuchElementException is thrown in
+   * @return RemoteWebElement NoSuchElementWebDriverException is thrown in
    *    HttpCommandExecutor if no element is found.
    * @see WebDriverBy
    */

--- a/lib/support/events/EventFiringWebDriver.php
+++ b/lib/support/events/EventFiringWebDriver.php
@@ -135,7 +135,7 @@ class EventFiringWebDriver implements WebDriver, JavaScriptExecutor {
    */
   public function executeScript($script, array $arguments = array()) {
     if (!$this->driver instanceof JavaScriptExecutor) {
-      throw new UnsupportedOperationException(
+      throw new UnsupportedOperationWebDriverException(
         'driver does not implement JavaScriptExecutor'
       );
     }
@@ -158,7 +158,7 @@ class EventFiringWebDriver implements WebDriver, JavaScriptExecutor {
    */
   public function executeAsyncScript($script, array $arguments = array()) {
     if (!$this->driver instanceof JavaScriptExecutor) {
-      throw new UnsupportedOperationException(
+      throw new UnsupportedOperationWebDriverException(
         'driver does not implement JavaScriptExecutor'
       );
     }


### PR DESCRIPTION
These changes fix any conflicts of Exception class names with other packages like Phing. #181 attempted to fix this by putting the Exception classes in their own files, this pull request fixes the issue by renaming the Exception class so they all end in "WebDriverException" which makes it more clear what caused the Exception.

I realize that these class names were taken from the [the official Java API](http://selenium.googlecode.com/svn/trunk/docs/api/java/index.html?overview-summary.html), but keep in mind that the official Java API uses namespaces (packages) to prevent class name conflicts. As this project does not use namespaces, conflicts have to be reduced by making the class names as unique as possible.