### PR TITLE
Made RemoteWebElement extendable

### DIFF
--- a/lib/remote/RemoteWebElement.php
+++ b/lib/remote/RemoteWebElement.php
@@ -405,6 +405,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable {
    * @return RemoteWebElement
    */
   private function newElement($id) {
-    return new RemoteWebElement($this->executor, $id);
+    $class = get_class($this);
+    return new $class($this->executor, $id);
   }
 }


### PR DESCRIPTION
`newElement` uses the actual class' constructor to create new objects.

An alternative would have been to make the method protected (it is now private).

This change enables users to extend the `RemoteWebElement` API by subclassing it.