### PR TITLE
Fix: Update Composer binary in before_install section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ php:
   - 7
   - hhvm
 
-install:
+before_install:
   - composer self-update
+
+install:
   - composer install --no-interaction --prefer-source
 
 before_script:


### PR DESCRIPTION
This PR

* [x] updates Composer itself in the `before_install` section