### PR TITLE
Enhancement: Cache dependencies installed with Composer between Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ php:
   - 7
   - hhvm
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_install:
   - composer self-update
 


### PR DESCRIPTION
This PR

* [x] enables caching of dependencies installed with Composer on Travis

:information_desk_person: This should help speeding up builds.