### PR TITLE
Disable Firefox Reader View help tooltip

### DIFF
--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -195,10 +195,17 @@ class DesiredCapabilities implements WebDriverCapabilities {
    * @return DesiredCapabilities
    */
   public static function firefox() {
-    return new DesiredCapabilities(array(
+    $caps = new DesiredCapabilities(array(
       WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::FIREFOX,
       WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
     ));
+
+    // disable the "Reader View" help tooltip, which can hide elements in the window.document
+    $profile = new FirefoxProfile();
+    $profile->setPreference('reader.parse-on-load.enabled', false);
+    $caps->setCapability(FirefoxDriver::PROFILE, $profile);
+
+    return $caps;
   }
 
   /**


### PR DESCRIPTION
This tooltip can hide window.document elements, which can break tests.
See http://stackoverflow.com/questions/30764805/how-to-disable-reader-view-in-firefox-using-webdriver