### PR TITLE
RemoteWebElement: allow overriding construction

### DIFF
--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -430,7 +430,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor {
    * @param string $id The id of the element to be created.
    * @return RemoteWebElement
    */
-  private function newElement($id) {
+  protected function newElement($id) {
     return new RemoteWebElement($this->getExecuteMethod(), $id);
   }
 

--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -416,8 +416,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable {
    *
    * @return RemoteWebElement
    */
-  private function newElement($id) {
-    $class = get_class($this);
-    return new $class($this->executor, $id);
+  protected function newElement($id) {
+    return new static($this->executor, $id);
   }
 }

--- a/lib/Support/Events/EventFiringWebDriver.php
+++ b/lib/Support/Events/EventFiringWebDriver.php
@@ -85,7 +85,7 @@ class EventFiringWebDriver implements WebDriver, JavaScriptExecutor {
    * @param WebDriverElement $element
    * @return EventFiringWebElement
    */
-  private function newElement(WebDriverElement $element) {
+  protected function newElement(WebDriverElement $element) {
     return new EventFiringWebElement($element, $this->getDispatcher());
   }
 

--- a/lib/Support/Events/EventFiringWebElement.php
+++ b/lib/Support/Events/EventFiringWebElement.php
@@ -78,8 +78,8 @@ class EventFiringWebElement implements WebDriverElement, WebDriverLocatable {
    * @param WebDriverElement $element
    * @return EventFiringWebElement
    */
-  private function newElement(WebDriverElement $element) {
-    return new EventFiringWebElement($element, $this->getDispatcher());
+  protected function newElement(WebDriverElement $element) {
+    return new static($element, $this->getDispatcher());
   }
 
   /**


### PR DESCRIPTION
Previously, if a developer wanted to extend the RemoteWebElement()
class, you couldn't effectively do it (#217 got us part of the way).
The name of the class was hard-coded in a private factory
method of RemoteWebDriver that couldn't be overriden.

Now, a custom class that extends RemoteWebDriver can
construct a class derived from RemoteWebElement, allowing
extra functionality to be added to Elements themselves.

The same logic applies to the EventFiringWebElement.