### PR TITLE
FirefoxProfile: clean up temporary files

### DIFF
--- a/lib/Firefox/FirefoxProfile.php
+++ b/lib/Firefox/FirefoxProfile.php
@@ -157,17 +157,17 @@ class FirefoxProfile {
    */
   private function deleteDirectory($directory) {
     $dir = new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS);
-    $files = new RecursiveIteratorIterator($dir, RecursiveIteratorIterator::CHILD_FIRST);
+    $paths = new RecursiveIteratorIterator($dir, RecursiveIteratorIterator::CHILD_FIRST);
 
-    foreach($paths as $path) {
+    foreach ($paths as $path) {
       if ($path->isDir() && !$path->isLink()) {
         rmdir($path->getPathname());
       } else {
-        unlink($path->getPathname())
+        unlink($path->getPathname());
       }
     }
 
-    rmdir($directory;
+    rmdir($directory);
   }
   
   /**

--- a/lib/Firefox/FirefoxProfile.php
+++ b/lib/Firefox/FirefoxProfile.php
@@ -98,6 +98,11 @@ class FirefoxProfile {
     $zip->close();
 
     $profile = base64_encode(file_get_contents($temp_zip));
+
+    // clean up
+    rmdir($temp_dir);
+    unlink($temp_zip);
+    
     return $profile;
   }
 
@@ -122,6 +127,10 @@ class FirefoxProfile {
     mkdir($ext_dir, 0777, true);
 
     $this->extractTo($extension, $ext_dir);
+
+    // clean up
+    rmdir($temp_dir);
+    
     return $ext_dir;
   }
 

--- a/lib/Firefox/FirefoxProfile.php
+++ b/lib/Firefox/FirefoxProfile.php
@@ -169,6 +169,7 @@ class FirefoxProfile {
 
     rmdir($directory;
   }
+  
   /**
    * @param string $xpi        The path to the .xpi extension.
    * @param string $target_dir The path to the unzip directory.

--- a/lib/Firefox/FirefoxProfile.php
+++ b/lib/Firefox/FirefoxProfile.php
@@ -100,9 +100,9 @@ class FirefoxProfile {
     $profile = base64_encode(file_get_contents($temp_zip));
 
     // clean up
-    rmdir($temp_dir);
+    $this->deleteDirectory($temp_dir);
     unlink($temp_zip);
-    
+
     return $profile;
   }
 
@@ -129,8 +129,8 @@ class FirefoxProfile {
     $this->extractTo($extension, $ext_dir);
 
     // clean up
-    rmdir($temp_dir);
-    
+    $this->deleteDirectory($temp_dir);
+
     return $ext_dir;
   }
 
@@ -152,6 +152,23 @@ class FirefoxProfile {
     return $temp_dir;
   }
 
+  /**
+   * @param string $directory The path to the directory.
+   */
+  private function deleteDirectory($directory) {
+    $dir = new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS);
+    $files = new RecursiveIteratorIterator($dir, RecursiveIteratorIterator::CHILD_FIRST);
+
+    foreach($paths as $path) {
+      if ($path->isDir() && !$path->isLink()) {
+        rmdir($path->getPathname());
+      } else {
+        unlink($path->getPathname())
+      }
+    }
+
+    rmdir($directory;
+  }
   /**
    * @param string $xpi        The path to the .xpi extension.
    * @param string $target_dir The path to the unzip directory.


### PR DESCRIPTION
During profile setup, some temporary files/folders are created. These temporary files/folders can grow quite large, so clean them up after the profile has been constructed to prevent disk space issues.