### PR TITLE
Use sys_get_temp_dir rather than the empty string when calling tempnam.

### DIFF
--- a/lib/Firefox/FirefoxProfile.php
+++ b/lib/Firefox/FirefoxProfile.php
@@ -132,7 +132,7 @@ class FirefoxProfile {
     file_put_contents($temp_dir.'/user.js', $content);
 
     $zip = new ZipArchive();
-    $temp_zip = tempnam('', 'WebDriverFirefoxProfileZip');
+    $temp_zip = tempnam(sys_get_temp_dir(), 'WebDriverFirefoxProfileZip');
     $zip->open($temp_zip, ZipArchive::CREATE);
 
     $dir = new RecursiveDirectoryIterator($temp_dir);
@@ -195,7 +195,7 @@ class FirefoxProfile {
    * @throws WebDriverException
    */
   private function createTempDirectory($prefix = '') {
-    $temp_dir = tempnam('', $prefix);
+    $temp_dir = tempnam(sys_get_temp_dir(), $prefix);
     if (file_exists($temp_dir)) {
       unlink($temp_dir);
       mkdir($temp_dir);

--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -332,7 +332,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable {
     }
 
     // Create a temporary file in the system temp directory.
-    $temp_zip = tempnam('', 'WebDriverZip');
+    $temp_zip = tempnam(sys_get_temp_dir(), 'WebDriverZip');
     $zip = new ZipArchive();
     if ($zip->open($temp_zip, ZipArchive::CREATE) !== true) {
       return false;


### PR DESCRIPTION
The latter fails when using the empty string if an open_basedir restriction is
in effect.

Also refer to https://secure.php.net/manual/en/function.tempnam.php#93256