### PR TITLE
Fix strict standards error in ChromeDriver

### DIFF
--- a/lib/Chrome/ChromeDriver.php
+++ b/lib/Chrome/ChromeDriver.php
@@ -56,18 +56,15 @@ class ChromeDriver extends RemoteWebDriver {
   /**
    * Always throws an exception. Use ChromeDriver::start() instead.
    *
-   * @param string              $url                  The url of the remote server
-   * @param DesiredCapabilities $desired_capabilities The desired capabilities
-   * @param int|null            $timeout_in_ms
-   * @param int|null            $request_timeout_in_ms
-   *
    * @throws WebDriverException
    */
   public static function create(
     $url = 'http://localhost:4444/wd/hub',
     $desired_capabilities = null,
-    $timeout_in_ms = null,
-    $request_timeout_in_ms = null
+    $connection_timeout_in_ms = null,
+    $request_timeout_in_ms = null,
+    $http_proxy = null,
+    $http_proxy_port = null
   ) {
     throw new WebDriverException('Please use ChromeDriver::start() instead.');
   }


### PR DESCRIPTION
Running tests currently causes following strict standards error for us:

> PHP Strict standards:  Declaration of Facebook\WebDriver\Chrome\ChromeDriver::create() should be compatible with Facebook\WebDriver\Remote\RemoteWebDriver::create($url = 'http://loc...', $desired_capabilities = NULL, $connection_timeout_in_ms = NULL, $request_timeout_in_ms = NULL, $http_proxy = NULL, $http_proxy_port = NULL) in .../vendor/facebook/webdriver/lib/Chrome/ChromeDriver.php on line 89


 Though we do not use `ChromeDriver::create()` method (and it cannot be used either), it still must have compatible signature with the `RemoteWebDriver::create()` method (because `ChromeDriver` is extending `RemoteWebDriver`).

This PR updates the method declaration to match those in `RemoteWebDriver::create()`.