### PR TITLE
Fixed PHP Fatal crash in RemoteWebDriver:507

### DIFF
--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -504,7 +504,11 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor {
       $params
     );
 
-    $response = $this->executor->execute($command);
-    return $response->getValue();
+	if ($this->executor) {
+		$response = $this->executor->execute($command);
+		return $response->getValue();
+	} else {
+		return null;
+	}
   }
 }


### PR DESCRIPTION
This PR fixes the issue noted at https://github.com/facebook/php-webdriver/issues/254

It's possible for 

    $this->executor

to be null at the time that this method is called, resulting in a PHP Fatal Error.

It is readily replicated within Codeception when an element cannot be found.  There's an issue over at Codeception https://github.com/Codeception/Codeception/issues/518 for this, but it's really a problem with RemoteWebDriver and not Codeception's consuming class. 

This PR adds a check for this condition and avoids the Fatal Error.