### PR TITLE
Throw exception if XPI extension file doesn't exist.

### DIFF
--- a/lib/Firefox/FirefoxProfile.php
+++ b/lib/Firefox/FirefoxProfile.php
@@ -249,11 +249,15 @@ class FirefoxProfile {
    */
   private function extractTo($xpi, $target_dir) {
     $zip = new ZipArchive();
-    if ($zip->open($xpi)) {
-      $zip->extractTo($target_dir);
-      $zip->close();
+    if (file_exists($xpi)) {
+      if ($zip->open($xpi)) {
+        $zip->extractTo($target_dir);
+        $zip->close();
+      } else {
+        throw new \Exception("Failed to open the firefox extension. '$xpi'");
+      }
     } else {
-      throw new \Exception("Failed to open the firefox extension. '$xpi'");
+      throw new \Exception("Firefox extension doesn't exist. '$xpi'");
     }
     return $this;
   }


### PR DESCRIPTION
Update to make extractTo() throw an exception if the Firefox extension .xpi file doesn't exist, which should be the desired behavior.

Currently extractTo() only throws an error if the .xpi file exists AND is unable to open.

ZipArchive throws some Warning messages when you use extractTo() and close() on an initialized ZipArchive object which is the case if the file doesn't exist.