### PR TITLE
Initial Microsoft Edge support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Added initial basic support of Microsoft Edge browser
+
+## 1.1.3 - 2016-08-10
 - Fixed FirefoxProfile to support installation of extensions with custom namespace prefix in their manifest file
 - Comply codestyle with [PSR-2](http://www.php-fig.org/psr/psr-2/)
 

--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -274,6 +274,17 @@ class DesiredCapabilities implements WebDriverCapabilities
     /**
      * @return DesiredCapabilities
      */
+    public static function microsoftEdge()
+    {
+        return new self(array(
+            WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::MICROSOFT_EDGE,
+            WebDriverCapabilityType::PLATFORM => WebDriverPlatform::WINDOWS,
+        ));
+    }
+
+    /**
+     * @return DesiredCapabilities
+     */
     public static function iphone()
     {
         return new self(array(

--- a/lib/Remote/WebDriverBrowserType.php
+++ b/lib/Remote/WebDriverBrowserType.php
@@ -21,17 +21,15 @@ namespace Facebook\WebDriver\Remote;
 class WebDriverBrowserType
 {
     const FIREFOX = 'firefox';
-    const FIREFOX_2 = 'firefox2';
-    const FIREFOX_3 = 'firefox3';
     const FIREFOX_PROXY = 'firefoxproxy';
     const FIREFOX_CHROME = 'firefoxchrome';
     const GOOGLECHROME = 'googlechrome';
     const SAFARI = 'safari';
+    const SAFARI_PROXY = 'safariproxy';
     const OPERA = 'opera';
     const MICROSOFT_EDGE = 'MicrosoftEdge';
     const IEXPLORE = 'iexplore';
     const IEXPLORE_PROXY = 'iexploreproxy';
-    const SAFARI_PROXY = 'safariproxy';
     const CHROME = 'chrome';
     const KONQUEROR = 'konqueror';
     const MOCK = 'mock';

--- a/lib/Remote/WebDriverBrowserType.php
+++ b/lib/Remote/WebDriverBrowserType.php
@@ -28,6 +28,7 @@ class WebDriverBrowserType
     const GOOGLECHROME = 'googlechrome';
     const SAFARI = 'safari';
     const OPERA = 'opera';
+    const MICROSOFT_EDGE = 'MicrosoftEdge';
     const IEXPLORE = 'iexplore';
     const IEXPLORE_PROXY = 'iexploreproxy';
     const SAFARI_PROXY = 'safariproxy';

--- a/tests/unit/Remote/DesiredCapabilitiesTest.php
+++ b/tests/unit/Remote/DesiredCapabilitiesTest.php
@@ -110,6 +110,7 @@ class DesiredCapabilitiesTest extends \PHPUnit_Framework_TestCase
             array('firefox', WebDriverBrowserType::FIREFOX, WebDriverPlatform::ANY),
             array('htmlUnit', WebDriverBrowserType::HTMLUNIT, WebDriverPlatform::ANY),
             array('htmlUnitWithJS', WebDriverBrowserType::HTMLUNIT, WebDriverPlatform::ANY),
+            array('MicrosoftEdge', WebDriverBrowserType::MICROSOFT_EDGE, WebDriverPlatform::WINDOWS),
             array('internetExplorer', WebDriverBrowserType::IE, WebDriverPlatform::WINDOWS),
             array('iphone', WebDriverBrowserType::IPHONE, WebDriverPlatform::MAC),
             array('ipad', WebDriverBrowserType::IPAD, WebDriverPlatform::MAC),


### PR DESCRIPTION
This adds basic Microsoft Edge support - ie. only when Edge is used as a node. It still does not support starting Microsoft WebDriver executable locally - as it is [supported by eg. the official Java bindings ](https://github.com/SeleniumHQ/selenium/blob/c10e8a955883f004452cdde18096d70738397788/java/client/src/org/openqa/selenium/edge/EdgeDriverService.java), because this would require implementing the `EdgeDriverService` (which would extend `DriverService`, similary as [`ChromeDriverService` does](https://github.com/facebook/php-webdriver/blob/b7186fb1bcfda956d237f59face250d06ef47253/lib/Chrome/ChromeDriverService.php)). So the issue  #244 is still partially valid. But as a Linux user this full support would be quite difficult for me to implement and especially test - help from Windows users would be much appreciated!

However, when Edge is running as node (either on cloud service like Sauce Labs or BrowserStack) or as part of your Selenium grid, you can now start it easily using these predefined constant and desired capabilities:

```
$driver = RemoteWebDriver::create($host, DesiredCapabilities::microsoftEdge());
```

I also removed constants of some browsers no longer supported by Selenium, as per the [official  java bindings](https://github.com/SeleniumHQ/selenium/blob/master/java/client/src/org/openqa/selenium/remote/BrowserType.java).