### PR TITLE
Utilize late static binding

### DIFF
--- a/lib/Chrome/ChromeDriverService.php
+++ b/lib/Chrome/ChromeDriverService.php
@@ -27,7 +27,7 @@ class ChromeDriverService extends DriverService
         $exe = getenv(self::CHROME_DRIVER_EXE_PROPERTY);
         $port = 9515; // TODO: Get another port if the default port is used.
         $args = array("--port=$port");
-        $service = new self($exe, $port, $args);
+        $service = new static($exe, $port, $args);
 
         return $service;
     }

--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -201,7 +201,7 @@ class DesiredCapabilities implements WebDriverCapabilities
      */
     public static function android()
     {
-        return new self(array(
+        return new static(array(
             WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::ANDROID,
             WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANDROID,
         ));
@@ -212,7 +212,7 @@ class DesiredCapabilities implements WebDriverCapabilities
      */
     public static function chrome()
     {
-        return new self(array(
+        return new static(array(
             WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::CHROME,
             WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
         ));
@@ -223,7 +223,7 @@ class DesiredCapabilities implements WebDriverCapabilities
      */
     public static function firefox()
     {
-        $caps = new self(array(
+        $caps = new static(array(
             WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::FIREFOX,
             WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
         ));
@@ -241,7 +241,7 @@ class DesiredCapabilities implements WebDriverCapabilities
      */
     public static function htmlUnit()
     {
-        return new self(array(
+        return new static(array(
             WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::HTMLUNIT,
             WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
         ));
@@ -252,7 +252,7 @@ class DesiredCapabilities implements WebDriverCapabilities
      */
     public static function htmlUnitWithJS()
     {
-        $caps = new self(array(
+        $caps = new static(array(
             WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::HTMLUNIT,
             WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
         ));
@@ -265,7 +265,7 @@ class DesiredCapabilities implements WebDriverCapabilities
      */
     public static function internetExplorer()
     {
-        return new self(array(
+        return new static(array(
             WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::IE,
             WebDriverCapabilityType::PLATFORM => WebDriverPlatform::WINDOWS,
         ));
@@ -276,7 +276,7 @@ class DesiredCapabilities implements WebDriverCapabilities
      */
     public static function microsoftEdge()
     {
-        return new self(array(
+        return new static(array(
             WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::MICROSOFT_EDGE,
             WebDriverCapabilityType::PLATFORM => WebDriverPlatform::WINDOWS,
         ));
@@ -287,7 +287,7 @@ class DesiredCapabilities implements WebDriverCapabilities
      */
     public static function iphone()
     {
-        return new self(array(
+        return new static(array(
             WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::IPHONE,
             WebDriverCapabilityType::PLATFORM => WebDriverPlatform::MAC,
         ));
@@ -298,7 +298,7 @@ class DesiredCapabilities implements WebDriverCapabilities
      */
     public static function ipad()
     {
-        return new self(array(
+        return new static(array(
             WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::IPAD,
             WebDriverCapabilityType::PLATFORM => WebDriverPlatform::MAC,
         ));
@@ -309,7 +309,7 @@ class DesiredCapabilities implements WebDriverCapabilities
      */
     public static function opera()
     {
-        return new self(array(
+        return new static(array(
             WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::OPERA,
             WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
         ));
@@ -320,7 +320,7 @@ class DesiredCapabilities implements WebDriverCapabilities
      */
     public static function safari()
     {
-        return new self(array(
+        return new static(array(
             WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::SAFARI,
             WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
         ));
@@ -331,7 +331,7 @@ class DesiredCapabilities implements WebDriverCapabilities
      */
     public static function phantomjs()
     {
-        return new self(array(
+        return new static(array(
             WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::PHANTOMJS,
             WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
         ));

--- a/lib/WebDriverBy.php
+++ b/lib/WebDriverBy.php
@@ -58,7 +58,7 @@ class WebDriverBy
      */
     public static function className($class_name)
     {
-        return new self('class name', $class_name);
+        return new static('class name', $class_name);
     }
 
     /**
@@ -69,7 +69,7 @@ class WebDriverBy
      */
     public static function cssSelector($css_selector)
     {
-        return new self('css selector', $css_selector);
+        return new static('css selector', $css_selector);
     }
 
     /**
@@ -80,7 +80,7 @@ class WebDriverBy
      */
     public static function id($id)
     {
-        return new self('id', $id);
+        return new static('id', $id);
     }
 
     /**
@@ -91,7 +91,7 @@ class WebDriverBy
      */
     public static function name($name)
     {
-        return new self('name', $name);
+        return new static('name', $name);
     }
 
     /**
@@ -102,7 +102,7 @@ class WebDriverBy
      */
     public static function linkText($link_text)
     {
-        return new self('link text', $link_text);
+        return new static('link text', $link_text);
     }
 
     /**
@@ -114,7 +114,7 @@ class WebDriverBy
      */
     public static function partialLinkText($partial_link_text)
     {
-        return new self('partial link text', $partial_link_text);
+        return new static('partial link text', $partial_link_text);
     }
 
     /**
@@ -125,7 +125,7 @@ class WebDriverBy
      */
     public static function tagName($tag_name)
     {
-        return new self('tag name', $tag_name);
+        return new static('tag name', $tag_name);
     }
 
     /**
@@ -136,6 +136,6 @@ class WebDriverBy
      */
     public static function xpath($xpath)
     {
-        return new self('xpath', $xpath);
+        return new static('xpath', $xpath);
     }
 }

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -55,7 +55,7 @@ class WebDriverExpectedCondition
      */
     public static function titleIs($title)
     {
-        return new self(
+        return new static(
             function ($driver) use ($title) {
                 return $title === $driver->getTitle();
             }
@@ -71,7 +71,7 @@ class WebDriverExpectedCondition
      */
     public static function titleContains($title)
     {
-        return new self(
+        return new static(
             function ($driver) use ($title) {
                 return strpos($driver->getTitle(), $title) !== false;
             }
@@ -88,7 +88,7 @@ class WebDriverExpectedCondition
      */
     public static function presenceOfElementLocated(WebDriverBy $by)
     {
-        return new self(
+        return new static(
             function ($driver) use ($by) {
                 return $driver->findElement($by);
             }
@@ -106,7 +106,7 @@ class WebDriverExpectedCondition
      */
     public static function visibilityOfElementLocated(WebDriverBy $by)
     {
-        return new self(
+        return new static(
             function ($driver) use ($by) {
                 try {
                     $element = $driver->findElement($by);
@@ -130,7 +130,7 @@ class WebDriverExpectedCondition
      */
     public static function visibilityOf(WebDriverElement $element)
     {
-        return new self(
+        return new static(
             function ($driver) use ($element) {
                 return $element->isDisplayed() ? $element : null;
             }
@@ -147,7 +147,7 @@ class WebDriverExpectedCondition
      */
     public static function presenceOfAllElementsLocatedBy(WebDriverBy $by)
     {
-        return new self(
+        return new static(
             function ($driver) use ($by) {
                 $elements = $driver->findElements($by);
 
@@ -166,7 +166,7 @@ class WebDriverExpectedCondition
      */
     public static function textToBePresentInElement(WebDriverBy $by, $text)
     {
-        return new self(
+        return new static(
             function ($driver) use ($by, $text) {
                 try {
                     $element_text = $driver->findElement($by)->getText();
@@ -189,7 +189,7 @@ class WebDriverExpectedCondition
      */
     public static function textToBePresentInElementValue(WebDriverBy $by, $text)
     {
-        return new self(
+        return new static(
             function ($driver) use ($by, $text) {
                 try {
                     $element_text = $driver->findElement($by)->getAttribute('value');
@@ -213,7 +213,7 @@ class WebDriverExpectedCondition
      */
     public static function frameToBeAvailableAndSwitchToIt($frame_locator)
     {
-        return new self(
+        return new static(
             function ($driver) use ($frame_locator) {
                 try {
                     return $driver->switchTo()->frame($frame_locator);
@@ -234,7 +234,7 @@ class WebDriverExpectedCondition
      */
     public static function invisibilityOfElementLocated(WebDriverBy $by)
     {
-        return new self(
+        return new static(
             function ($driver) use ($by) {
                 try {
                     return !($driver->findElement($by)->isDisplayed());
@@ -258,7 +258,7 @@ class WebDriverExpectedCondition
      */
     public static function invisibilityOfElementWithText(WebDriverBy $by, $text)
     {
-        return new self(
+        return new static(
             function ($driver) use ($by, $text) {
                 try {
                     return !($driver->findElement($by)->getText() === $text);
@@ -284,7 +284,7 @@ class WebDriverExpectedCondition
         $visibility_of_element_located =
             self::visibilityOfElementLocated($by);
 
-        return new self(
+        return new static(
             function ($driver) use ($visibility_of_element_located) {
                 $element = call_user_func(
                     $visibility_of_element_located->getApply(),
@@ -312,7 +312,7 @@ class WebDriverExpectedCondition
      */
     public static function stalenessOf(WebDriverElement $element)
     {
-        return new self(
+        return new static(
             function ($driver) use ($element) {
                 try {
                     $element->isEnabled();
@@ -340,7 +340,7 @@ class WebDriverExpectedCondition
      */
     public static function refreshed(WebDriverExpectedCondition $condition)
     {
-        return new self(
+        return new static(
             function ($driver) use ($condition) {
                 try {
                     return call_user_func($condition->getApply(), $driver);
@@ -375,14 +375,14 @@ class WebDriverExpectedCondition
     public static function elementSelectionStateToBe($element_or_by, $selected)
     {
         if ($element_or_by instanceof WebDriverElement) {
-            return new self(
+            return new static(
                 function ($driver) use ($element_or_by, $selected) {
                     return $element_or_by->isSelected() === $selected;
                 }
             );
         } else {
             if ($element_or_by instanceof WebDriverBy) {
-                return new self(
+                return new static(
                     function ($driver) use ($element_or_by, $selected) {
                         try {
                             $element = $driver->findElement($element_or_by);
@@ -405,7 +405,7 @@ class WebDriverExpectedCondition
      */
     public static function alertIsPresent()
     {
-        return new self(
+        return new static(
             function ($driver) {
                 try {
                     // Unlike the Java code, we get a WebDriverAlert object regardless
@@ -430,7 +430,7 @@ class WebDriverExpectedCondition
      */
     public static function not(WebDriverExpectedCondition $condition)
     {
-        return new self(
+        return new static(
             function ($driver) use ($condition) {
                 $result = call_user_func($condition->getApply(), $driver);
 


### PR DESCRIPTION
I came across the issue when I was trying to extend `WebDriverBy` class, it uses a whole bunch of `new self(...)` statements which restricts the extension by other classes. The same is for a few other classes.  

This PR aims to fix the issue across all affected classes by utilizing late static binding (`new static`) instead. LSB is introduced in PHP 5.3 which meets project's PHP version requirements.

This also addresses #285.