### PR TITLE
Fixes incompatibility with Appium

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
   "require-dev": {
     "phpunit/phpunit": "4.6.* || ~5.0",
     "friendsofphp/php-cs-fixer": "^1.11",
-    "squizlabs/php_codesniffer": "^2.6"
+    "squizlabs/php_codesniffer": "^2.6",
+    "php-mock/php-mock-phpunit": "^1.1"
   },
   "suggest": {
     "phpdocumentor/phpdocumentor": "2.*"

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -240,9 +240,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         foreach ($params as $name => $value) {
             if ($name[0] === ':') {
                 $url = str_replace($name, $value, $url);
-                if ($http_method != 'POST') {
-                    unset($params[$name]);
-                }
+                unset($params[$name]);
             }
         }
 

--- a/tests/unit/Remote/HttpCommandExecutorTest.php
+++ b/tests/unit/Remote/HttpCommandExecutorTest.php
@@ -1,0 +1,94 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Facebook\WebDriver\Remote;
+
+use phpmock\phpunit\PHPMock;
+
+class HttpCommandExecutorTest extends \PHPUnit_Framework_TestCase
+{
+    use PHPMock;
+    /** @var HttpCommandExecutor */
+    private $executor;
+
+    public function setUp()
+    {
+        $this->executor = new HttpCommandExecutor('http://localhost:4444');
+    }
+
+    /**
+     * @dataProvider commandProvider
+     * @param int $command
+     * @param array $params
+     * @param string $expectedUrl
+     * @param string $expectedPostData
+     */
+    public function testShouldSendRequestToAssembledUrl($command, array $params, $expectedUrl, $expectedPostData)
+    {
+        $command = new WebDriverCommand('foo-123', $command, $params);
+
+        $curlSetoptMock = $this->getFunctionMock(__NAMESPACE__, 'curl_setopt');
+        $curlSetoptMock->expects($this->at(0))
+            ->with($this->anything(), CURLOPT_URL, $expectedUrl);
+
+        $curlSetoptMock->expects($this->at(2))
+            ->with($this->anything(), CURLOPT_POSTFIELDS, $expectedPostData);
+
+        $curlExecMock = $this->getFunctionMock(__NAMESPACE__, 'curl_exec');
+        $curlExecMock->expects($this->once())
+            ->willReturn('{}');
+
+        $this->executor->execute($command);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function commandProvider()
+    {
+        return [
+            'POST command having :id placeholder in url' => [
+                DriverCommand::SEND_KEYS_TO_ELEMENT,
+                ['value' => 'submitted-value', ':id' => '1337'],
+                'http://localhost:4444/session/foo-123/element/1337/value',
+                '{"value":"submitted-value"}',
+            ],
+            'POST command without :id placeholder in url' => [
+                DriverCommand::TOUCH_UP,
+                ['x' => 3, 'y' => 6],
+                'http://localhost:4444/session/foo-123/touch/up',
+                '{"x":3,"y":6}',
+            ],
+            'Extra useless placeholder parameter should be removed' => [
+                DriverCommand::TOUCH_UP,
+                ['x' => 3, 'y' => 6, ':useless' => 'foo'],
+                'http://localhost:4444/session/foo-123/touch/up',
+                '{"x":3,"y":6}',
+            ],
+            'DELETE command' => [
+                DriverCommand::DELETE_COOKIE,
+                [':name' => 'cookie-name'],
+                'http://localhost:4444/session/foo-123/cookie/cookie-name',
+                null,
+            ],
+            'GET command without session in URL' => [
+                DriverCommand::GET_ALL_SESSIONS,
+                [],
+                'http://localhost:4444/sessions',
+                null,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Do not set URL placeholder params as part of POST body. This fixes incompatibility with Appium, caused by redundant params present in requests to Selenium server.

See #323.