### PR TITLE
Use Symfony Process component to start local webdriver processes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
   },
   "require": {
     "php": "^5.5 || ~7.0",
+    "symfony/process": "^2.8 || ^3.1",
     "ext-curl": "*"
   },
   "require-dev": {


### PR DESCRIPTION
As in #299, I was unable to start ChromeDriver directly (ie. without Selenium server) and I also have no luck determining the cause (the process got stuck somehow). I was able to fix it by replacing the `proc_open()` with [Symfony Process component](https://symfony.com/doc/current/components/process.html). 

The Process component itself uses the proc_open(), however, it adds compatibility layer, worarounds for some [PHP bugs](https://github.com/php/php-src/pull/1588) and encapsulates the whole started process, so it can be easily manipulated (and started asynchronously).

Even though I cannot verify it fixes #299, it makes starting of the process more portable. What do others think?
