### PR TITLE
Add new expected conditions + unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,21 @@
 This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Added
+- Added `getCapabilities()` method of `RemoteWebDriver`, to retrieve actual capabilities acknowledged by the remote driver on startup.
+- Added option to pass required capabilities when creating `RemoteWebDriver`. (So far only desired capabilities were supported.)
+- Added new expected conditions:
+    - `titleMatches` - current page title matches regular expression
+    - `elementTextIs` - text in element exactly equals given text
+    - `elementTextMatches` - text in element matches regular expression
+    - `elementTextContains` (as an alias for `textToBePresentInElement`) - text in element contains given text
+    - `numberOfWindowsToBe` - number of opened windows equals given number
+
+### Changed
 - `Symfony\Process` is used to start local WebDriver processes (when browsers are run directly, without Selenium server) to workaround some PHP bugs and improve portability.
 - Clarified meaning of selenium server URL variable in methods of `RemoteWebDriver` class.
 - Deprecated `setSessionID()` and `setCommandExecutor()` methods of `RemoteWebDriver` class; these values should be immutable and thus passed only via constructor.
-- Added `getCapabilities()` method of `RemoteWebDriver`, to retrieve actual capabilities acknowledged by the remote driver on startup.
-- Added option to pass required capabilities when creating `RemoteWebDriver`. (So far only desired capabilities were supported.)
+- Deprecated `WebDriverExpectedCondition::textToBePresentInElement()` in favor of `elementTextContains()`
 
 ## 1.2.0 - 2016-10-14
 - Added initial support of remote Microsoft Edge browser (but starting local EdgeDriver is still not supported).

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -167,11 +167,26 @@ class WebDriverExpectedCondition
      * An expectation for checking if the given text is present in the specified element.
      * To check exact text match use elementTextIs() condition.
      *
+     * @codeCoverageIgnore
+     * @deprecated Use WebDriverExpectedCondition::elementTextContains() instead
      * @param WebDriverBy $by The locator used to find the element.
      * @param string $text The text to be presented in the element.
      * @return bool WebDriverExpectedCondition Whether the text is present.
      */
     public static function textToBePresentInElement(WebDriverBy $by, $text)
+    {
+        return self::elementTextContains($by, $text);
+    }
+
+    /**
+     * An expectation for checking if the given text is present in the specified element.
+     * To check exact text match use elementTextIs() condition.
+     *
+     * @param WebDriverBy $by The locator used to find the element.
+     * @param string $text The text to be presented in the element.
+     * @return bool WebDriverExpectedCondition Whether the text is present.
+     */
+    public static function elementTextContains(WebDriverBy $by, $text)
     {
         return new static(
             function (WebDriver $driver) use ($by, $text) {
@@ -188,7 +203,7 @@ class WebDriverExpectedCondition
 
     /**
      * An expectation for checking if the given text exactly equals the text in specified element.
-     * To check only partial substring of the text use textToBePresentInElement() condition.
+     * To check only partial substring of the text use elementTextContains() condition.
      *
      * @param WebDriverBy $by The locator used to find the element.
      * @param string $text The expected text of the element.

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -165,6 +165,7 @@ class WebDriverExpectedCondition
 
     /**
      * An expectation for checking if the given text is present in the specified element.
+     * To check exact text match use elementTextIs() condition.
      *
      * @param WebDriverBy $by The locator used to find the element.
      * @param string $text The text to be presented in the element.
@@ -178,6 +179,47 @@ class WebDriverExpectedCondition
                     $element_text = $driver->findElement($by)->getText();
 
                     return strpos($element_text, $text) !== false;
+                } catch (StaleElementReferenceException $e) {
+                    return null;
+                }
+            }
+        );
+    }
+
+    /**
+     * An expectation for checking if the given text exactly equals the text in specified element.
+     * To check only partial substring of the text use textToBePresentInElement() condition.
+     *
+     * @param WebDriverBy $by The locator used to find the element.
+     * @param string $text The expected text of the element.
+     * @return bool WebDriverExpectedCondition True when element has text value equal to given one
+     */
+    public static function elementTextIs(WebDriverBy $by, $text)
+    {
+        return new static(
+            function (WebDriver $driver) use ($by, $text) {
+                try {
+                    return $driver->findElement($by)->getText() == $text;
+                } catch (StaleElementReferenceException $e) {
+                    return null;
+                }
+            }
+        );
+    }
+
+    /**
+     * An expectation for checking if the given regular expression matches the text in specified element.
+     *
+     * @param WebDriverBy $by The locator used to find the element.
+     * @param string $regexp The regular expression to test against.
+     * @return bool WebDriverExpectedCondition True when element has text value equal to given one
+     */
+    public static function elementTextMatches(WebDriverBy $by, $regexp)
+    {
+        return new static(
+            function (WebDriver $driver) use ($by, $regexp) {
+                try {
+                    return (bool) preg_match($regexp, $driver->findElement($by)->getText());
                 } catch (StaleElementReferenceException $e) {
                     return null;
                 }

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -78,6 +78,21 @@ class WebDriverExpectedCondition
     }
 
     /**
+     * An expectation for checking current page title matches the given regular expression.
+     *
+     * @param string $titleRegexp The regular expression to test against.
+     * @return bool WebDriverExpectedCondition True when in title, false otherwise.
+     */
+    public static function titleMatches($titleRegexp)
+    {
+        return new static(
+            function (WebDriver $driver) use ($titleRegexp) {
+                return (bool) preg_match($titleRegexp, $driver->getTitle());
+            }
+        );
+    }
+
+    /**
      * An expectation for checking that an element is present on the DOM of a page.
      * This does not necessarily mean that the element is visible.
      *

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -475,6 +475,21 @@ class WebDriverExpectedCondition
     }
 
     /**
+     * An expectation checking the number of opened windows.
+     *
+     * @param int $expectedNumberOfWindows
+     * @return WebDriverExpectedCondition
+     */
+    public static function numberOfWindowsToBe($expectedNumberOfWindows)
+    {
+        return new static(
+            function (WebDriver $driver) use ($expectedNumberOfWindows) {
+                return count($driver->getWindowHandles()) == $expectedNumberOfWindows;
+            }
+        );
+    }
+
+    /**
      * An expectation with the logical opposite condition of the given condition.
      *
      * @param WebDriverExpectedCondition $condition The condition to be negated.

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -78,8 +78,8 @@ class WebDriverExpectedCondition
     }
 
     /**
-     * An expectation for checking that an element is present on the DOM of a
-     * page. This does not necessarily mean that the element is visible.
+     * An expectation for checking that an element is present on the DOM of a page.
+     * This does not necessarily mean that the element is visible.
      *
      * @param WebDriverBy $by The locator used to find the element.
      * @return WebDriverExpectedCondition<WebDriverElement> The element which is located.
@@ -94,9 +94,25 @@ class WebDriverExpectedCondition
     }
 
     /**
-     * An expectation for checking that an element is present on the DOM of a page
-     * and visible. Visibility means that the element is not only displayed but
-     * also has a height and width that is greater than 0.
+     * An expectation for checking that there is at least one element present on a web page.
+     *
+     * @param WebDriverBy $by The locator used to find the element.
+     * @return WebDriverExpectedCondition<array> An array of WebDriverElements once they are located.
+     */
+    public static function presenceOfAllElementsLocatedBy(WebDriverBy $by)
+    {
+        return new static(
+            function (WebDriver $driver) use ($by) {
+                $elements = $driver->findElements($by);
+
+                return count($elements) > 0 ? $elements : null;
+            }
+        );
+    }
+
+    /**
+     * An expectation for checking that an element is present on the DOM of a page and visible.
+     * Visibility means that the element is not only displayed but also has a height and width that is greater than 0.
      *
      * @param WebDriverBy $by The locator used to find the element.
      * @return WebDriverExpectedCondition<WebDriverElement> The element which is located and visible.
@@ -117,9 +133,8 @@ class WebDriverExpectedCondition
     }
 
     /**
-     * An expectation for checking that an element, known to be present on the DOM
-     * of a page, is visible. Visibility means that the element is not only
-     * displayed but also has a height and width that is greater than 0.
+     * An expectation for checking that an element, known to be present on the DOM of a page, is visible.
+     * Visibility means that the element is not only displayed but also has a height and width that is greater than 0.
      *
      * @param WebDriverElement $element The element to be checked.
      * @return WebDriverExpectedCondition<WebDriverElement> The same WebDriverElement once it is visible.
@@ -134,30 +149,11 @@ class WebDriverExpectedCondition
     }
 
     /**
-     * An expectation for checking that there is at least one element present on a
-     * web page.
-     *
-     * @param WebDriverBy $by The locator used to find the element.
-     * @return WebDriverExpectedCondition<array> An array of WebDriverElements once they are located.
-     */
-    public static function presenceOfAllElementsLocatedBy(WebDriverBy $by)
-    {
-        return new static(
-            function (WebDriver $driver) use ($by) {
-                $elements = $driver->findElements($by);
-
-                return count($elements) > 0 ? $elements : null;
-            }
-        );
-    }
-
-    /**
-     * An expectation for checking if the given text is present in the specified
-     * element.
+     * An expectation for checking if the given text is present in the specified element.
      *
      * @param WebDriverBy $by The locator used to find the element.
      * @param string $text The text to be presented in the element.
-     * @return bool WebDriverExpectedCondition Whether the text is presented.
+     * @return bool WebDriverExpectedCondition Whether the text is present.
      */
     public static function textToBePresentInElement(WebDriverBy $by, $text)
     {
@@ -175,8 +171,7 @@ class WebDriverExpectedCondition
     }
 
     /**
-     * An expectation for checking if the given text is present in the specified
-     * elements value attribute.
+     * An expectation for checking if the given text is present in the specified elements value attribute.
      *
      * @param WebDriverBy $by The locator used to find the element.
      * @param string $text The text to be presented in the element value.
@@ -198,8 +193,7 @@ class WebDriverExpectedCondition
     }
 
     /**
-     * Expectation for checking if iFrame exists.
-     * If iFrame exists switches driver's focus to the iFrame
+     * Expectation for checking if iFrame exists. If iFrame exists switches driver's focus to the iFrame.
      *
      * @param string $frame_locator The locator used to find the iFrame
      *   expected to be either the id or name value of the i/frame
@@ -220,8 +214,7 @@ class WebDriverExpectedCondition
     }
 
     /**
-     * An expectation for checking that an element is either invisible or not
-     * present on the DOM.
+     * An expectation for checking that an element is either invisible or not present on the DOM.
      *
      * @param WebDriverBy $by The locator used to find the element.
      * @return bool WebDriverExpectedCondition Whether there is no element located.
@@ -231,7 +224,7 @@ class WebDriverExpectedCondition
         return new static(
             function (WebDriver $driver) use ($by) {
                 try {
-                    return !($driver->findElement($by)->isDisplayed());
+                    return !$driver->findElement($by)->isDisplayed();
                 } catch (NoSuchElementException $e) {
                     return true;
                 } catch (StaleElementReferenceException $e) {
@@ -242,8 +235,7 @@ class WebDriverExpectedCondition
     }
 
     /**
-     * An expectation for checking that an element with text is either invisible
-     * or not present on the DOM.
+     * An expectation for checking that an element with text is either invisible or not present on the DOM.
      *
      * @param WebdriverBy $by The locator used to find the element.
      * @param string $text The text of the element.
@@ -265,8 +257,7 @@ class WebDriverExpectedCondition
     }
 
     /**
-     * An expectation for checking an element is visible and enabled such that you
-     * can click it.
+     * An expectation for checking an element is visible and enabled such that you can click it.
      *
      * @param WebDriverBy $by The locator used to find the element
      * @return WebDriverExpectedCondition<WebDriverElement> The WebDriverElement
@@ -320,11 +311,10 @@ class WebDriverExpectedCondition
     /**
      * Wrapper for a condition, which allows for elements to update by redrawing.
      *
-     * This works around the problem of conditions which have two parts: find an
-     * element and then check for some condition on it. For these conditions it is
-     * possible that an element is located and then subsequently it is redrawn on
-     * the client. When this happens a StaleElementReferenceException is thrown
-     * when the second part of the condition is checked.
+     * This works around the problem of conditions which have two parts: find an element and then check for some
+     * condition on it. For these conditions it is possible that an element is located and then subsequently it is
+     * redrawn on the client. When this happens a StaleElementReferenceException is thrown when the second part of
+     * the condition is checked.
      *
      * @param WebDriverExpectedCondition $condition The condition wrapped.
      * @return WebDriverExpectedCondition<mixed> The return value of the getApply() of the given condition.

--- a/tests/functional/RemoteWebDriverTest.php
+++ b/tests/functional/RemoteWebDriverTest.php
@@ -20,10 +20,13 @@ use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\WebDriverBrowserType;
 
 /**
- * @covers Facebook\WebDriver\Remote\RemoteWebDriver
+ * @coversDefaultClass Facebook\WebDriver\Remote\RemoteWebDriver
  */
 class RemoteWebDriverTest extends WebDriverTestCase
 {
+    /**
+     * @covers ::getTitle
+     */
     public function testShouldGetPageTitle()
     {
         $this->driver->get($this->getTestPath('index.html'));
@@ -34,6 +37,10 @@ class RemoteWebDriverTest extends WebDriverTestCase
         );
     }
 
+    /**
+     * @covers ::getCurrentURL
+     * @covers ::get
+     */
     public function testShouldGetCurrentUrl()
     {
         $this->driver->get($this->getTestPath('index.html'));
@@ -44,6 +51,9 @@ class RemoteWebDriverTest extends WebDriverTestCase
         );
     }
 
+    /**
+     * @covers ::getPageSource
+     */
     public function testShouldGetPageSource()
     {
         $this->driver->get($this->getTestPath('index.html'));
@@ -53,6 +63,9 @@ class RemoteWebDriverTest extends WebDriverTestCase
         $this->assertContains('Welcome to the facebook/php-webdriver testing page.', $source);
     }
 
+    /**
+     * @covers ::getSessionID
+     */
     public function testShouldGetSessionId()
     {
         $sessionId = $this->driver->getSessionID();
@@ -61,6 +74,9 @@ class RemoteWebDriverTest extends WebDriverTestCase
         $this->assertNotEmpty($sessionId);
     }
 
+    /**
+     * @covers ::getAllSessions
+     */
     public function testShouldGetAllSessions()
     {
         $sessions = RemoteWebDriver::getAllSessions();
@@ -73,6 +89,11 @@ class RemoteWebDriverTest extends WebDriverTestCase
         $this->assertArrayHasKey('class', $sessions[0]);
     }
 
+    /**
+     * @covers ::getAllSessions
+     * @covers ::getCommandExecutor
+     * @covers ::quit
+     */
     public function testShouldQuitAndUnsetExecutor()
     {
         $this->assertCount(1, RemoteWebDriver::getAllSessions());
@@ -84,6 +105,10 @@ class RemoteWebDriverTest extends WebDriverTestCase
         $this->assertNull($this->driver->getCommandExecutor());
     }
 
+    /**
+     * @covers ::getWindowHandle
+     * @covers ::getWindowHandles
+     */
     public function testShouldGetWindowHandles()
     {
         $this->driver->get($this->getTestPath('open_new_window.html'));
@@ -105,6 +130,9 @@ class RemoteWebDriverTest extends WebDriverTestCase
         $this->assertCount(2, $this->driver->getWindowHandles());
     }
 
+    /**
+     * @covers ::getWindowHandles
+     */
     public function testShouldCloseWindow()
     {
         $this->driver->get($this->getTestPath('open_new_window.html'));
@@ -117,6 +145,9 @@ class RemoteWebDriverTest extends WebDriverTestCase
         $this->assertCount(1, $this->driver->getWindowHandles());
     }
 
+    /**
+     * @covers ::executeScript
+     */
     public function testShouldExecuteScriptAndDoNotBlockExecution()
     {
         $this->driver->get($this->getTestPath('index.html'));
@@ -138,6 +169,9 @@ class RemoteWebDriverTest extends WebDriverTestCase
         $this->assertSame('Text changed by script', $element->getText());
     }
 
+    /**
+     * @covers ::executeAsyncScript
+     */
     public function testShouldExecuteAsyncScriptAndWaitUntilItIsFinished()
     {
         $this->driver->manage()->timeouts()->setScriptTimeout(1);
@@ -163,6 +197,9 @@ class RemoteWebDriverTest extends WebDriverTestCase
         $this->assertSame('Text changed by script', $element->getText());
     }
 
+    /**
+     * @covers ::takeScreenshot
+     */
     public function testShouldTakeScreenshot()
     {
         if (!extension_loaded('gd')) {
@@ -183,6 +220,9 @@ class RemoteWebDriverTest extends WebDriverTestCase
         $this->assertGreaterThan(0, imagesy($image));
     }
 
+    /**
+     * @covers ::takeScreenshot
+     */
     public function testShouldSaveScreenshotToFile()
     {
         if (!extension_loaded('gd')) {

--- a/tests/functional/RemoteWebDriverTest.php
+++ b/tests/functional/RemoteWebDriverTest.php
@@ -98,6 +98,10 @@ class RemoteWebDriverTest extends WebDriverTestCase
         // Open second window
         $this->driver->findElement(WebDriverBy::cssSelector('a'))->click();
 
+        $this->driver->wait()->until(
+            WebDriverExpectedCondition::numberOfWindowsToBe(2)
+        );
+
         $this->assertCount(2, $this->driver->getWindowHandles());
     }
 

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -162,7 +162,7 @@ class WebDriverExpectedConditionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($element, $this->wait->until($condition));
     }
 
-    public function testShouldDetectTextToBePresentInElementCondition()
+    public function testShouldDetectElementTextContainsCondition()
     {
         // Set-up the consecutive calls to apply() as follows:
         // Call #1: throws NoSuchElementException
@@ -185,7 +185,7 @@ class WebDriverExpectedConditionTest extends \PHPUnit_Framework_TestCase
 
         $this->setupDriverToReturnElementAfterAnException($element, 4);
 
-        $condition = WebDriverExpectedCondition::textToBePresentInElement(WebDriverBy::cssSelector('.foo'), 'new');
+        $condition = WebDriverExpectedCondition::elementTextContains(WebDriverBy::cssSelector('.foo'), 'new');
 
         $this->assertTrue($this->wait->until($condition));
     }

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -1,0 +1,210 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Facebook\WebDriver;
+
+use Facebook\WebDriver\Exception\NoSuchElementException;
+use Facebook\WebDriver\Exception\StaleElementReferenceException;
+use Facebook\WebDriver\Remote\RemoteExecuteMethod;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Facebook\WebDriver\Remote\RemoteWebElement;
+
+/**
+ * @covers Facebook\WebDriver\WebDriverExpectedCondition
+ */
+class WebDriverExpectedConditionTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var RemoteWebDriver|\PHPUnit_Framework_MockObject_MockObject */
+    private $driverMock;
+    /** @var WebDriverWait */
+    private $wait;
+
+    protected function setUp()
+    {
+        // TODO: replace with createMock() once PHP 5.5 support is dropped
+        $this->driverMock = $this
+            ->getMockBuilder(RemoteWebDriver::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->wait = new WebDriverWait($this->driverMock, 1, 1);
+    }
+
+    public function testShouldDetectTitleIsCondition()
+    {
+        $this->driverMock->expects($this->any())
+            ->method('getTitle')
+            ->willReturnOnConsecutiveCalls('old', 'oldwithnew', 'new');
+
+        $condition = WebDriverExpectedCondition::titleIs('new');
+
+        $this->assertFalse(call_user_func($condition->getApply(), $this->driverMock));
+        $this->assertFalse(call_user_func($condition->getApply(), $this->driverMock));
+        $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
+    }
+
+    public function testShouldDetectTitleContainsCondition()
+    {
+        $this->driverMock->expects($this->any())
+            ->method('getTitle')
+            ->willReturnOnConsecutiveCalls('old', 'oldwithnew', 'new');
+
+        $condition = WebDriverExpectedCondition::titleContains('new');
+
+        $this->assertFalse(call_user_func($condition->getApply(), $this->driverMock));
+        $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
+        $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
+    }
+
+    public function testShouldDetectPresenceOfElementLocatedCondition()
+    {
+        $element = new RemoteWebElement(new RemoteExecuteMethod($this->driverMock), 'id');
+
+        $this->driverMock->expects($this->at(0))
+            ->method('findElement')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willThrowException(new NoSuchElementException(''));
+
+        $this->driverMock->expects($this->at(1))
+            ->method('findElement')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willReturn($element);
+
+        $condition = WebDriverExpectedCondition::presenceOfElementLocated(WebDriverBy::cssSelector('.foo'));
+
+        $this->assertSame($element, $this->wait->until($condition));
+    }
+
+    public function testShouldDetectPresenceOfAllElementsLocatedByCondition()
+    {
+        $element = $this->createRemoteWebElementMock();
+
+        $this->driverMock->expects($this->at(0))
+            ->method('findElements')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willReturn([]);
+
+        $this->driverMock->expects($this->at(1))
+            ->method('findElements')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willReturn([$element]);
+
+        $condition = WebDriverExpectedCondition::presenceOfAllElementsLocatedBy(WebDriverBy::cssSelector('.foo'));
+
+        $this->assertSame([$element], $this->wait->until($condition));
+    }
+
+    public function testShouldDetectVisibilityOfElementLocatedCondition()
+    {
+        // Set-up the consecutive calls to apply() as follows:
+        // Call #1: throws NoSuchElementException
+        // Call #2: return Element, but isDisplayed will throw StaleElementReferenceException
+        // Call #3: return Element, but isDisplayed will return false
+        // Call #4: return Element, isDisplayed will true and condition will match
+
+        $element = $this->createRemoteWebElementMock();
+        $element->expects($this->at(0))
+            ->method('isDisplayed')
+            ->willThrowException(new StaleElementReferenceException(''));
+
+        $element->expects($this->at(1))
+            ->method('isDisplayed')
+            ->willReturn(false);
+
+        $element->expects($this->at(2))
+            ->method('isDisplayed')
+            ->willReturn(true);
+
+        $this->driverMock->expects($this->at(0))
+            ->method('findElement')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willThrowException(new NoSuchElementException(''));
+
+        $this->driverMock->expects($this->at(1))
+            ->method('findElement')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willReturn($element);
+
+        $this->driverMock->expects($this->at(2))
+            ->method('findElement')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willReturn($element);
+
+        $this->driverMock->expects($this->at(3))
+            ->method('findElement')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willReturn($element);
+
+        $condition = WebDriverExpectedCondition::visibilityOfElementLocated(WebDriverBy::cssSelector('.foo'));
+
+        $this->assertSame($element, $this->wait->until($condition));
+    }
+
+    public function testShouldDetectVisibilityOfCondition()
+    {
+        $element = $this->createRemoteWebElementMock();
+        $element->expects($this->at(0))
+            ->method('isDisplayed')
+            ->willReturn(false);
+
+        $element->expects($this->at(1))
+            ->method('isDisplayed')
+            ->willReturn(true);
+
+        $condition = WebDriverExpectedCondition::visibilityOf($element);
+
+        $this->assertSame($element, $this->wait->until($condition));
+    }
+
+    public function testShouldDetectTextToBePresentInElementCondition()
+    {
+        // Set-up the consecutive calls to apply() as follows:
+        // Call #1: throws NoSuchElementException
+        // Call #2: return Element, but getText returns an old text
+        // Call #3: return Element, but getText will throw StaleElementReferenceException
+        // Call #4: return Element, getText will return new text and condition will match
+
+        $element = $this->createRemoteWebElementMock();
+        $element->expects($this->at(0))
+            ->method('getText')
+            ->willReturn('this is an old text');
+
+        $element->expects($this->at(1))
+            ->method('getText')
+            ->willThrowException(new StaleElementReferenceException(''));
+
+        $element->expects($this->at(2))
+            ->method('getText')
+            ->willReturn('this is a new text');
+
+        $this->setupDriverToReturnElementAfterAnException($element, 4);
+
+        $condition = WebDriverExpectedCondition::textToBePresentInElement(WebDriverBy::cssSelector('.foo'), 'new');
+
+        $this->assertTrue($this->wait->until($condition));
+    }
+
+    /**
+     * @todo Replace with createMock() once PHP 5.5 support is dropped
+     * @return \PHPUnit_Framework_MockObject_MockObject|RemoteWebElement
+     */
+    private function createRemoteWebElementMock()
+    {
+        return $this->getMockBuilder(RemoteWebElement::class)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->getMock();
+    }
+}

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -67,6 +67,19 @@ class WebDriverExpectedConditionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
     }
 
+    public function testShouldDetectTitleMatchesCondition()
+    {
+        $this->driverMock->expects($this->any())
+            ->method('getTitle')
+            ->willReturnOnConsecutiveCalls('non-matching', 'matching-not', 'matching-123');
+
+        $condition = WebDriverExpectedCondition::titleMatches('/matching-\d{3}/');
+
+        $this->assertFalse(call_user_func($condition->getApply(), $this->driverMock));
+        $this->assertFalse(call_user_func($condition->getApply(), $this->driverMock));
+        $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
+    }
+
     public function testShouldDetectPresenceOfElementLocatedCondition()
     {
         $element = new RemoteWebElement(new RemoteExecuteMethod($this->driverMock), 'id');

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -253,6 +253,19 @@ class WebDriverExpectedConditionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->wait->until($condition));
     }
 
+    public function testShouldDetectNumberOfWindowsToBeCondition()
+    {
+        $this->driverMock->expects($this->any())
+            ->method('getWindowHandles')
+            ->willReturnOnConsecutiveCalls(['one'], ['one', 'two', 'three'], ['one', 'two']);
+
+        $condition = WebDriverExpectedCondition::numberOfWindowsToBe(2);
+
+        $this->assertFalse(call_user_func($condition->getApply(), $this->driverMock));
+        $this->assertFalse(call_user_func($condition->getApply(), $this->driverMock));
+        $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
+    }
+
     /**
      * @param RemoteWebElement $element
      * @param int $expectedNumberOfFindElementCalls


### PR DESCRIPTION
Inspired by official Java, Python and Javascript bindings, following new expected conditions were added:
- `titleMatches`
- `elementTextIs`
- `elementTextMatches`
- `elementTextContains` (as an alias for `textToBePresentInElement`)
- `numberOfWindowsToBe`

Also, in #370, the urlIs, urlContains and maybe urlMatches conditions will be added as well.

For consistency, I also suggest deprecating the `textToBePresentInElement()` condition in favor of the `elementTextContains`. It s IMHO easier to find with code-completion in IDE, and the naming will be much more systematic and readable:

- elementText[Is, Matches, Contains]
- title[Is, Matches, Contains]
- url[Is, Matches, Contains]

What does other think about this change?