### PR TITLE
Support required capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,31 +2,32 @@
 This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-- `Symfony\Process` is used to start local WebDriver processes (when browsers are run directly, without Selenium server) to workaround some PHP bugs and improve poratbility
-- Clarified meaning of selenium server URL variable in methods of `RemoteWebDriver` class
+- `Symfony\Process` is used to start local WebDriver processes (when browsers are run directly, without Selenium server) to workaround some PHP bugs and improve portability.
+- Clarified meaning of selenium server URL variable in methods of `RemoteWebDriver` class.
 - Deprecated `setSessionID()` and `setCommandExecutor()` methods of `RemoteWebDriver` class; these values should be immutable and thus passed only via constructor.
 - Added `getCapabilities()` method of `RemoteWebDriver`, to retrieve actual capabilities acknowledged by the remote driver on startup.
+- Added option to pass required capabilities when creating `RemoteWebDriver`. (So far only desired capabilities were supported.)
 
 ## 1.2.0 - 2016-10-14
-- Added initial support of remote Microsoft Edge browser (but starting local EdgeDriver is still not supported)
-- Utilize late static binding to make eg. `WebDriverBy` and `DesiredCapabilities` classes easily extensible
-- PHP version at least 5.5 is required
-- Fixed incompatibility with Appium, caused by redundant params present in requests to Selenium server
+- Added initial support of remote Microsoft Edge browser (but starting local EdgeDriver is still not supported).
+- Utilize late static binding to make eg. `WebDriverBy` and `DesiredCapabilities` classes easily extensible.
+- PHP version at least 5.5 is required.
+- Fixed incompatibility with Appium, caused by redundant params present in requests to Selenium server.
 
 ## 1.1.3 - 2016-08-10
-- Fixed FirefoxProfile to support installation of extensions with custom namespace prefix in their manifest file
-- Comply codestyle with [PSR-2](http://www.php-fig.org/psr/psr-2/)
+- Fixed FirefoxProfile to support installation of extensions with custom namespace prefix in their manifest file.
+- Comply codestyle with [PSR-2](http://www.php-fig.org/psr/psr-2/).
 
 ## 1.1.2 - 2016-06-04
-- Added ext-curl to composer.json
-- Added CHANGELOG.md
-- Added CONTRIBUTING.md with information and rules for contributors
+- Added ext-curl to composer.json.
+- Added CHANGELOG.md.
+- Added CONTRIBUTING.md with information and rules for contributors.
 
 ## 1.1.1 - 2015-12-31
-- Fixed strict standards error in `ChromeDriver`
-- Added unit tests for `WebDriverCommand` and `DesiredCapabilities`
-- Fixed retrieving temporary path name in `FirefoxDriver` when `open_basedir` restriction is in effect 
+- Fixed strict standards error in `ChromeDriver`.
+- Added unit tests for `WebDriverCommand` and `DesiredCapabilities`.
+- Fixed retrieving temporary path name in `FirefoxDriver` when `open_basedir` restriction is in effect.
 
 ## 1.1.0 - 2015-12-08
-- FirefoxProfile improved - added possibility to set RDF file and to add datas for extensions
-- Fixed setting 0 second timeout of `WebDriverWait`
+- FirefoxProfile improved - added possibility to set RDF file and to add datas for extensions.
+- Fixed setting 0 second timeout of `WebDriverWait`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 - `Symfony\Process` is used to start local WebDriver processes (when browsers are run directly, without Selenium server) to workaround some PHP bugs and improve poratbility
--  Clarified meaning of selenium server URL variable in methods of `RemoteWebDriver` class
+- Clarified meaning of selenium server URL variable in methods of `RemoteWebDriver` class
+- Deprecated `setSessionID()` and `setCommandExecutor()` methods of `RemoteWebDriver` class; these values should be immutable and thus passed only via constructor.
+- Added `getCapabilities()` method of `RemoteWebDriver`, to retrieve actual capabilities acknowledged by the remote driver on startup.
 
 ## 1.2.0 - 2016-10-14
 - Added initial support of remote Microsoft Edge browser (but starting local EdgeDriver is still not supported)

--- a/lib/Chrome/ChromeDriver.php
+++ b/lib/Chrome/ChromeDriver.php
@@ -33,9 +33,8 @@ class ChromeDriver extends RemoteWebDriver
             $service = ChromeDriverService::createDefaultService();
         }
         $executor = new DriverCommandExecutor($service);
-        $driver = new static();
-        $driver->setCommandExecutor($executor)
-            ->startSession($desired_capabilities);
+        $driver = new static($executor, null, $desired_capabilities);
+        $driver->startSession($desired_capabilities);
 
         return $driver;
     }
@@ -50,7 +49,7 @@ class ChromeDriver extends RemoteWebDriver
             ]
         );
         $response = $this->executor->execute($command);
-        $this->setSessionID($response->getSessionID());
+        $this->sessionID = $response->getSessionID();
     }
 
     /**

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -224,7 +224,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
      * @param WebDriverCommand $command
      *
      * @throws WebDriverException
-     * @return mixed
+     * @return WebDriverResponse
      */
     public function execute(WebDriverCommand $command)
     {

--- a/lib/Remote/Service/DriverCommandExecutor.php
+++ b/lib/Remote/Service/DriverCommandExecutor.php
@@ -19,6 +19,7 @@ use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\Remote\DriverCommand;
 use Facebook\WebDriver\Remote\HttpCommandExecutor;
 use Facebook\WebDriver\Remote\WebDriverCommand;
+use Facebook\WebDriver\Remote\WebDriverResponse;
 
 /**
  * A HttpCommandExecutor that talks to a local driver service instead of
@@ -42,7 +43,7 @@ class DriverCommandExecutor extends HttpCommandExecutor
      *
      * @throws WebDriverException
      * @throws \Exception
-     * @return mixed
+     * @return WebDriverResponse
      */
     public function execute(WebDriverCommand $command)
     {

--- a/lib/WebDriverCommandExecutor.php
+++ b/lib/WebDriverCommandExecutor.php
@@ -16,6 +16,7 @@
 namespace Facebook\WebDriver;
 
 use Facebook\WebDriver\Remote\WebDriverCommand;
+use Facebook\WebDriver\Remote\WebDriverResponse;
 
 /**
  * Interface for all command executor.
@@ -25,7 +26,7 @@ interface WebDriverCommandExecutor
     /**
      * @param WebDriverCommand $command
      *
-     * @return mixed
+     * @return WebDriverResponse
      */
     public function execute(WebDriverCommand $command);
 }

--- a/tests/functional/FileUploadTest.php
+++ b/tests/functional/FileUploadTest.php
@@ -17,6 +17,10 @@ namespace Facebook\WebDriver;
 
 use Facebook\WebDriver\Remote\LocalFileDetector;
 
+/**
+ * @covers Facebook\WebDriver\Remote\LocalFileDetector
+ * @covers Facebook\WebDriver\Remote\RemoteWebElement
+ */
 class FileUploadTest extends WebDriverTestCase
 {
     public function testShouldUploadAFile()

--- a/tests/functional/RemoteWebDriverCreateTest.php
+++ b/tests/functional/RemoteWebDriverCreateTest.php
@@ -1,0 +1,63 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Facebook\WebDriver;
+
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Facebook\WebDriver\Remote\HttpCommandExecutor;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+
+/**
+ * @covers Facebook\WebDriver\Remote\RemoteWebDriver
+ * @covers Facebook\WebDriver\Remote\HttpCommandExecutor
+ */
+class RemoteWebDriverCreateTest extends WebDriverTestCase
+{
+    protected $createWebDriver = false;
+
+    public function testShouldStartBrowserAndCreateInstanceOfRemoteWebDriver()
+    {
+        $this->driver = RemoteWebDriver::create($this->serverUrl, $this->desiredCapabilities, 10000, 13370);
+
+        $this->assertInstanceOf(RemoteWebDriver::class, $this->driver);
+
+        $this->assertInstanceOf(HttpCommandExecutor::class, $this->driver->getCommandExecutor());
+        $this->assertSame($this->serverUrl, $this->driver->getCommandExecutor()->getAddressOfRemoteServer());
+
+        $this->assertInternalType('string', $this->driver->getSessionID());
+        $this->assertNotEmpty($this->driver->getSessionID());
+
+        $returnedCapabilities = $this->driver->getCapabilities();
+        $this->assertInstanceOf(WebDriverCapabilities::class, $returnedCapabilities);
+        $this->assertSame($this->desiredCapabilities->getBrowserName(), $returnedCapabilities->getBrowserName());
+    }
+
+    public function testShouldCreateWebDriverWithRequiredCapabilities()
+    {
+        $requiredCapabilities = new DesiredCapabilities();
+
+        $this->driver = RemoteWebDriver::create(
+            $this->serverUrl,
+            $this->desiredCapabilities,
+            null,
+            null,
+            null,
+            null,
+            $requiredCapabilities
+        );
+
+        $this->assertInstanceOf(RemoteWebDriver::class, $this->driver);
+    }
+}

--- a/tests/functional/RemoteWebDriverFindElementTest.php
+++ b/tests/functional/RemoteWebDriverFindElementTest.php
@@ -20,6 +20,9 @@ use Facebook\WebDriver\Remote\RemoteWebElement;
 
 /**
  * Tests for findElement() and findElements() method of RemoteWebDriver.
+ * @covers Facebook\WebDriver\Remote\RemoteWebDriver
+ * @covers Facebook\WebDriver\Exception\WebDriverException
+ * @covers Facebook\WebDriver\Exception\NoSuchElementException
  */
 class RemoteWebDriverFindElementTest extends WebDriverTestCase
 {

--- a/tests/functional/RemoteWebDriverTest.php
+++ b/tests/functional/RemoteWebDriverTest.php
@@ -19,6 +19,9 @@ use Facebook\WebDriver\Remote\HttpCommandExecutor;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\WebDriverBrowserType;
 
+/**
+ * @covers Facebook\WebDriver\Remote\RemoteWebDriver
+ */
 class RemoteWebDriverTest extends WebDriverTestCase
 {
     public function testShouldGetPageTitle()

--- a/tests/functional/RemoteWebElementTest.php
+++ b/tests/functional/RemoteWebElementTest.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver;
 
+/**
+ * @covers Facebook\WebDriver\Remote\RemoteWebElement
+ */
 class RemoteWebElementTest extends WebDriverTestCase
 {
     public function testShouldGetText()

--- a/tests/functional/WebDriverByTest.php
+++ b/tests/functional/WebDriverByTest.php
@@ -19,6 +19,7 @@ use Facebook\WebDriver\Remote\RemoteWebElement;
 
 /**
  * Tests for locator strategies provided by WebDriverBy.
+ * @covers Facebook\WebDriver\WebDriverBy
  */
 class WebDriverByTest extends WebDriverTestCase
 {

--- a/tests/functional/WebDriverByTest.php
+++ b/tests/functional/WebDriverByTest.php
@@ -25,18 +25,21 @@ class WebDriverByTest extends WebDriverTestCase
 {
     /**
      * @dataProvider textElementsProvider
-     * @param WebDriverBy $locator
+     * @param $webDriverByLocatorMethod
+     * @param $webDriverByLocatorValue
      * @param string $expectedText
      * @param string $expectedAttributeValue
      */
     public function testShouldFindTextElementByLocator(
-        WebDriverBy $locator,
+        $webDriverByLocatorMethod,
+        $webDriverByLocatorValue,
         $expectedText = null,
         $expectedAttributeValue = null
     ) {
         $this->driver->get($this->getTestPath('index.html'));
 
-        $element = $this->driver->findElement($locator);
+        $by = call_user_func([WebDriverBy::class, $webDriverByLocatorMethod], $webDriverByLocatorValue);
+        $element = $this->driver->findElement($by);
 
         $this->assertInstanceOf(RemoteWebElement::class, $element);
 
@@ -52,14 +55,14 @@ class WebDriverByTest extends WebDriverTestCase
     public function textElementsProvider()
     {
         return [
-            'id' => [WebDriverBy::id('id_test'), 'Test by ID'],
-            'className' => [WebDriverBy::className('test_class'), 'Test by Class'],
-            'cssSelector' => [WebDriverBy::cssSelector('.test_class'), 'Test by Class'],
-            'linkText' => [WebDriverBy::linkText('Click here'), 'Click here'],
-            'partialLinkText' => [WebDriverBy::partialLinkText('Click'), 'Click here'],
-            'xpath' => [WebDriverBy::xpath('//input[@name="test_name"]'), '', 'Test Value'],
-            'name' => [WebDriverBy::name('test_name'), '', 'Test Value'],
-            'tagName' => [WebDriverBy::tagName('input'), '', 'Test Value'],
+            'id' => ['id', 'id_test', 'Test by ID'],
+            'className' => ['className', 'test_class', 'Test by Class'],
+            'cssSelector' => ['cssSelector', '.test_class', 'Test by Class'],
+            'linkText' => ['linkText', 'Click here', 'Click here'],
+            'partialLinkText' => ['partialLinkText', 'Click', 'Click here'],
+            'xpath' => ['xpath', '//input[@name="test_name"]', '', 'Test Value'],
+            'name' => ['name', 'test_name', '', 'Test Value'],
+            'tagName' => ['tagName', 'input', '', 'Test Value'],
         ];
     }
 }

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -25,6 +25,11 @@ use Facebook\WebDriver\Remote\WebDriverBrowserType;
  */
 class WebDriverTestCase extends \PHPUnit_Framework_TestCase
 {
+    /** @var bool Indicate whether WebDriver should be created on setUp */
+    protected $createWebDriver = true;
+    /** @var string */
+    protected $serverUrl = 'http://localhost:4444/wd/hub';
+
     /** @var RemoteWebDriver $driver */
     protected $driver;
     /** @var DesiredCapabilities */
@@ -33,7 +38,6 @@ class WebDriverTestCase extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->desiredCapabilities = new DesiredCapabilities();
-        $serverUrl = 'http://localhost:4444/wd/hub';
 
         if (getenv('BROWSER_NAME')) {
             $browserName = getenv('BROWSER_NAME');
@@ -43,12 +47,14 @@ class WebDriverTestCase extends \PHPUnit_Framework_TestCase
 
         $this->desiredCapabilities->setBrowserName($browserName);
 
-        $this->driver = RemoteWebDriver::create($serverUrl, $this->desiredCapabilities);
+        if ($this->createWebDriver) {
+            $this->driver = RemoteWebDriver::create($this->serverUrl, $this->desiredCapabilities);
+        }
     }
 
     protected function tearDown()
     {
-        if ($this->driver->getCommandExecutor()) {
+        if ($this->driver instanceof RemoteWebDriver && $this->driver->getCommandExecutor()) {
             try {
                 $this->driver->quit();
             } catch (NoSuchWindowException $e) {


### PR DESCRIPTION
Required capabilities are present for a long time in eg. Java bindings. And they are also part of the WebDriver W3C specification - see https://w3c.github.io/webdriver/webdriver-spec.html#processing-capabilities .

Currently Selenium server accept them only as part of `desiredCapabilities`; in future (when this part of the W3C spec will be implemented in Selenium) they will be passed in a different way (in `alwaysMatch` and `firstMatch` properties) - however it will be just an implementation change, with no impact to end users calling the `RemoteWebDriver::create`.

This will also help to workaround #334.

### TODO:
- [x] Write tests for RemoteWebDriver and the capabilities setup (incl. getCommandExecutor)
- [x] Set capabilities returned in the NEW_SESSION response to a property of RemoteWebDriver object (+ add test for it)