### PR TITLE
Select enhacements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
     - `elementTextMatches` - text in element matches regular expression
     - `numberOfWindowsToBe` - number of opened windows equals given number
 - Possibility to select option of `<select>` by its partial text (using `selectByVisiblePartialText()`)
+- `XPathEscaper` helper class to quote XPaths containing both single and double quotes.
 
 ### Changed
 - `Symfony\Process` is used to start local WebDriver processes (when browsers are run directly, without Selenium server) to workaround some PHP bugs and improve portability.
@@ -22,6 +23,9 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 - Deprecated `setSessionID()` and `setCommandExecutor()` methods of `RemoteWebDriver` class; these values should be immutable and thus passed only via constructor.
 - Deprecated `WebDriverExpectedCondition::textToBePresentInElement()` in favor of `elementTextContains()`
 - Throw an exception when attempting to deselect options of non-multiselect (it already didn't have any effect, but was silently ignored).
+
+### Fixed
+- XPath escaping in `select*()` and `deselect*()` methods of `WebDriverSelect`.
 
 ## 1.2.0 - 2016-10-14
 - Added initial support of remote Microsoft Edge browser (but starting local EdgeDriver is still not supported).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 - Clarified meaning of selenium server URL variable in methods of `RemoteWebDriver` class.
 - Deprecated `setSessionID()` and `setCommandExecutor()` methods of `RemoteWebDriver` class; these values should be immutable and thus passed only via constructor.
 - Deprecated `WebDriverExpectedCondition::textToBePresentInElement()` in favor of `elementTextContains()`
+- Throw an exception when attempting to deselect options of non-multiselect (it already didn't have any effect, but was silently ignored).
 
 ## 1.2.0 - 2016-10-14
 - Added initial support of remote Microsoft Edge browser (but starting local EdgeDriver is still not supported).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
     - `numberOfWindowsToBe` - number of opened windows equals given number
 - Possibility to select option of `<select>` by its partial text (using `selectByVisiblePartialText()`)
 - `XPathEscaper` helper class to quote XPaths containing both single and double quotes.
+- `WebDriverSelectInterface`, to allow implementation of custom select-like components, eg. those not built around and actual select tag.
 
 ### Changed
 - `Symfony\Process` is used to start local WebDriver processes (when browsers are run directly, without Selenium server) to workaround some PHP bugs and improve portability.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
     - `elementTextContains` (as an alias for `textToBePresentInElement`) - text in element contains given text
     - `elementTextMatches` - text in element matches regular expression
     - `numberOfWindowsToBe` - number of opened windows equals given number
+- Possibility to select option of `<select>` by its partial text (using `selectByVisiblePartialText()`)
 
 ### Changed
 - `Symfony\Process` is used to start local WebDriver processes (when browsers are run directly, without Selenium server) to workaround some PHP bugs and improve portability.

--- a/lib/Support/XPathEscaper.php
+++ b/lib/Support/XPathEscaper.php
@@ -1,0 +1,45 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Facebook\WebDriver\Support;
+
+class XPathEscaper
+{
+    /**
+     * Converts xpath strings with both quotes and ticks into:
+     *   foo'"bar -> concat('foo', "'" ,'"bar')
+     *
+     * @param string $xpathToEscape The xpath to be converted.
+     * @return string The escaped string.
+     */
+    public static function escapeQuotes($xpathToEscape)
+    {
+        // Single quotes not present => we can quote in them
+        if (strpos($xpathToEscape, "'") === false) {
+            return sprintf("'%s'", $xpathToEscape);
+        }
+
+        // Double quotes not present => we can quote in them
+        if (strpos($xpathToEscape, '"') === false) {
+            return sprintf('"%s"', $xpathToEscape);
+        }
+
+        // Both single and double quotes are present
+        return sprintf(
+            "concat('%s')",
+            str_replace("'", "', \"'\" ,'", $xpathToEscape)
+        );
+    }
+}

--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -18,6 +18,7 @@ namespace Facebook\WebDriver;
 use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\Exception\UnexpectedTagNameException;
 use Facebook\WebDriver\Exception\UnsupportedOperationException;
+use Facebook\WebDriver\Support\XPathEscaper;
 
 /**
  * Models a SELECT tag, providing helper methods to select and deselect options.
@@ -128,7 +129,7 @@ class WebDriverSelect
     public function selectByValue($value)
     {
         $matched = false;
-        $xpath = './/option[@value = ' . $this->escapeQuotes($value) . ']';
+        $xpath = './/option[@value = ' . XPathEscaper::escapeQuotes($value) . ']';
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
 
         foreach ($options as $option) {
@@ -161,7 +162,7 @@ class WebDriverSelect
     public function selectByVisibleText($text)
     {
         $matched = false;
-        $xpath = './/option[normalize-space(.) = ' . $this->escapeQuotes($text) . ']';
+        $xpath = './/option[normalize-space(.) = ' . XPathEscaper::escapeQuotes($text) . ']';
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
 
         foreach ($options as $option) {
@@ -210,7 +211,7 @@ class WebDriverSelect
     public function selectByVisiblePartialText($text)
     {
         $matched = false;
-        $xpath = './/option[contains(normalize-space(.), ' . $this->escapeQuotes($text) . ')]';
+        $xpath = './/option[contains(normalize-space(.), ' . XPathEscaper::escapeQuotes($text) . ')]';
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
 
         foreach ($options as $option) {
@@ -282,7 +283,7 @@ class WebDriverSelect
             throw new UnsupportedOperationException('You may only deselect options of a multi-select');
         }
 
-        $xpath = './/option[@value = ' . $this->escapeQuotes($value) . ']';
+        $xpath = './/option[@value = ' . XPathEscaper::escapeQuotes($value) . ']';
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
         foreach ($options as $option) {
             if ($option->isSelected()) {
@@ -306,7 +307,7 @@ class WebDriverSelect
             throw new UnsupportedOperationException('You may only deselect options of a multi-select');
         }
 
-        $xpath = './/option[normalize-space(.) = ' . $this->escapeQuotes($text) . ']';
+        $xpath = './/option[normalize-space(.) = ' . XPathEscaper::escapeQuotes($text) . ']';
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
         foreach ($options as $option) {
             if ($option->isSelected()) {
@@ -330,44 +331,12 @@ class WebDriverSelect
             throw new UnsupportedOperationException('You may only deselect options of a multi-select');
         }
 
-        $xpath = './/option[contains(normalize-space(.), ' . $this->escapeQuotes($text) . ')]';
+        $xpath = './/option[contains(normalize-space(.), ' . XPathEscaper::escapeQuotes($text) . ')]';
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
         foreach ($options as $option) {
             if ($option->isSelected()) {
                 $option->click();
             }
         }
-    }
-
-    /**
-     * Convert strings with both quotes and ticks into:
-     *   foo'"bar -> concat("foo'", '"', "bar")
-     *
-     * @param string $to_escape The string to be converted.
-     * @return string The escaped string.
-     */
-    protected function escapeQuotes($to_escape)
-    {
-        if (strpos($to_escape, '"') !== false && strpos($to_escape, "'") !== false) {
-            $substrings = explode('"', $to_escape);
-
-            $escaped = 'concat(';
-            $first = true;
-            foreach ($substrings as $string) {
-                if (!$first) {
-                    $escaped .= ", '\"',";
-                    $first = false;
-                }
-                $escaped .= '"' . $string . '"';
-            }
-
-            return $escaped;
-        }
-
-        if (strpos($to_escape, '"') !== false) {
-            return sprintf("'%s'", $to_escape);
-        }
-
-        return sprintf('"%s"', $to_escape);
     }
 }

--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -220,6 +220,39 @@ class WebDriverSelect
     }
 
     /**
+     * Select all options that display text partially matching the argument. That is, when
+     * given "Bar" this would select an option like:
+     *
+     * <option value="bar">Foo Bar Baz</option>;
+     *
+     * @param string $text The visible text to match against.
+     *
+     * @throws NoSuchElementException
+     */
+    public function selectByVisiblePartialText($text)
+    {
+        $matched = false;
+        $xpath = './/option[contains(normalize-space(.), ' . $this->escapeQuotes($text) . ')]';
+        $options = $this->element->findElements(WebDriverBy::xpath($xpath));
+
+        foreach ($options as $option) {
+            if (!$option->isSelected()) {
+                $option->click();
+            }
+            if (!$this->isMultiple()) {
+                return;
+            }
+            $matched = true;
+        }
+
+        if (!$matched) {
+            throw new NoSuchElementException(
+                sprintf('Cannot locate option with text: %s', $text)
+            );
+        }
+    }
+
+    /**
      * Deselect the option at the given index.
      *
      * @param int $index The index of the option. (0-based)

--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -252,9 +252,14 @@ class WebDriverSelect
      * Deselect the option at the given index.
      *
      * @param int $index The index of the option. (0-based)
+     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
      */
     public function deselectByIndex($index)
     {
+        if (!$this->isMultiple()) {
+            throw new UnsupportedOperationException('You may only deselect options of a multi-select');
+        }
+
         foreach ($this->getOptions() as $option) {
             if ($option->getAttribute('index') === (string) $index && $option->isSelected()) {
                 $option->click();
@@ -269,9 +274,14 @@ class WebDriverSelect
      * <option value="foo">Bar</option>;
      *
      * @param string $value The value to match against.
+     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
      */
     public function deselectByValue($value)
     {
+        if (!$this->isMultiple()) {
+            throw new UnsupportedOperationException('You may only deselect options of a multi-select');
+        }
+
         $xpath = './/option[@value = ' . $this->escapeQuotes($value) . ']';
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
         foreach ($options as $option) {
@@ -288,9 +298,14 @@ class WebDriverSelect
      * <option value="foo">Bar</option>;
      *
      * @param string $text The visible text to match against.
+     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
      */
     public function deselectByVisibleText($text)
     {
+        if (!$this->isMultiple()) {
+            throw new UnsupportedOperationException('You may only deselect options of a multi-select');
+        }
+
         $xpath = './/option[normalize-space(.) = ' . $this->escapeQuotes($text) . ']';
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
         foreach ($options as $option) {

--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -99,9 +99,7 @@ class WebDriverSelect
     {
         foreach ($this->getOptions() as $option) {
             if ($option->getAttribute('index') === (string) $index) {
-                if (!$option->isSelected()) {
-                    $option->click();
-                }
+                $this->selectOption($option);
 
                 return;
             }
@@ -127,9 +125,7 @@ class WebDriverSelect
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
 
         foreach ($options as $option) {
-            if (!$option->isSelected()) {
-                $option->click();
-            }
+            $this->selectOption($option);
             if (!$this->isMultiple()) {
                 return;
             }
@@ -160,9 +156,7 @@ class WebDriverSelect
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
 
         foreach ($options as $option) {
-            if (!$option->isSelected()) {
-                $option->click();
-            }
+            $this->selectOption($option);
             if (!$this->isMultiple()) {
                 return;
             }
@@ -174,9 +168,7 @@ class WebDriverSelect
         if (!$matched) {
             foreach ($this->getOptions() as $option) {
                 if ($option->getText() === $text) {
-                    if (!$option->isSelected()) {
-                        $option->click();
-                    }
+                    $this->selectOption($option);
                     if (!$this->isMultiple()) {
                         return;
                     }
@@ -209,9 +201,7 @@ class WebDriverSelect
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
 
         foreach ($options as $option) {
-            if (!$option->isSelected()) {
-                $option->click();
-            }
+            $this->selectOption($option);
             if (!$this->isMultiple()) {
                 return;
             }
@@ -237,9 +227,7 @@ class WebDriverSelect
         }
 
         foreach ($this->getOptions() as $option) {
-            if ($option->isSelected()) {
-                $option->click();
-            }
+            $this->deselectOption($option);
         }
     }
 
@@ -257,9 +245,7 @@ class WebDriverSelect
 
         foreach ($this->getOptions() as $option) {
             if ($option->getAttribute('index') === (string) $index) {
-                if ($option->isSelected()) {
-                    $option->click();
-                }
+                $this->deselectOption($option);
 
                 return;
             }
@@ -284,9 +270,7 @@ class WebDriverSelect
         $xpath = './/option[@value = ' . XPathEscaper::escapeQuotes($value) . ']';
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
         foreach ($options as $option) {
-            if ($option->isSelected()) {
-                $option->click();
-            }
+            $this->deselectOption($option);
         }
     }
 
@@ -308,9 +292,7 @@ class WebDriverSelect
         $xpath = './/option[normalize-space(.) = ' . XPathEscaper::escapeQuotes($text) . ']';
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
         foreach ($options as $option) {
-            if ($option->isSelected()) {
-                $option->click();
-            }
+            $this->deselectOption($option);
         }
     }
 
@@ -332,9 +314,29 @@ class WebDriverSelect
         $xpath = './/option[contains(normalize-space(.), ' . XPathEscaper::escapeQuotes($text) . ')]';
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
         foreach ($options as $option) {
-            if ($option->isSelected()) {
-                $option->click();
-            }
+            $this->deselectOption($option);
+        }
+    }
+
+    /**
+     * Mark option selected
+     * @param WebDriverElement $option
+     */
+    protected function selectOption(WebDriverElement $option)
+    {
+        if (!$option->isSelected()) {
+            $option->click();
+        }
+    }
+
+    /**
+     * Mark option not selected
+     * @param WebDriverElement $option
+     */
+    protected function deselectOption(WebDriverElement $option)
+    {
+        if ($option->isSelected()) {
+            $option->click();
         }
     }
 }

--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -21,11 +21,13 @@ use Facebook\WebDriver\Exception\UnsupportedOperationException;
 use Facebook\WebDriver\Support\XPathEscaper;
 
 /**
- * Models a SELECT tag, providing helper methods to select and deselect options.
+ * Models a default HTML <select> tag, providing helper methods to select and deselect options.
  */
-class WebDriverSelect
+class WebDriverSelect implements WebDriverSelectInterface
 {
+    /** @var WebDriverElement */
     private $element;
+    /** @var bool */
     private $isMulti;
 
     public function __construct(WebDriverElement $element)
@@ -40,25 +42,16 @@ class WebDriverSelect
         $this->isMulti = ($value === 'true');
     }
 
-    /**
-     * @return bool Whether this select element support selecting multiple options.
-     */
     public function isMultiple()
     {
         return $this->isMulti;
     }
 
-    /**
-     * @return WebDriverElement[] All options belonging to this select tag.
-     */
     public function getOptions()
     {
         return $this->element->findElements(WebDriverBy::tagName('option'));
     }
 
-    /**
-     * @return WebDriverElement[] All selected options belonging to this select tag.
-     */
     public function getAllSelectedOptions()
     {
         $selected_options = [];
@@ -71,12 +64,6 @@ class WebDriverSelect
         return $selected_options;
     }
 
-    /**
-     * @throws NoSuchElementException
-     *
-     * @return WebDriverElement The first selected option in this select tag (or
-     *                          the currently selected option in a normal select)
-     */
     public function getFirstSelectedOption()
     {
         foreach ($this->getOptions() as $option) {
@@ -88,13 +75,6 @@ class WebDriverSelect
         throw new NoSuchElementException('No options are selected');
     }
 
-    /**
-     * Select the option at the given index.
-     *
-     * @param int $index The index of the option. (0-based)
-     *
-     * @throws NoSuchElementException
-     */
     public function selectByIndex($index)
     {
         foreach ($this->getOptions() as $option) {
@@ -108,16 +88,6 @@ class WebDriverSelect
         throw new NoSuchElementException(sprintf('Cannot locate option with index: %d', $index));
     }
 
-    /**
-     * Select all options that have value attribute matching the argument. That
-     * is, when given "foo" this would select an option like:
-     *
-     * <option value="foo">Bar</option>;
-     *
-     * @param string $value The value to match against.
-     *
-     * @throws NoSuchElementException
-     */
     public function selectByValue($value)
     {
         $matched = false;
@@ -139,16 +109,6 @@ class WebDriverSelect
         }
     }
 
-    /**
-     * Select all options that display text matching the argument. That is, when
-     * given "Bar" this would select an option like:
-     *
-     * <option value="foo">Bar</option>;
-     *
-     * @param string $text The visible text to match against.
-     *
-     * @throws NoSuchElementException
-     */
     public function selectByVisibleText($text)
     {
         $matched = false;
@@ -184,16 +144,6 @@ class WebDriverSelect
         }
     }
 
-    /**
-     * Select all options that display text partially matching the argument. That is, when
-     * given "Bar" this would select an option like:
-     *
-     * <option value="bar">Foo Bar Baz</option>;
-     *
-     * @param string $text The visible text to match against.
-     *
-     * @throws NoSuchElementException
-     */
     public function selectByVisiblePartialText($text)
     {
         $matched = false;
@@ -215,11 +165,6 @@ class WebDriverSelect
         }
     }
 
-    /**
-     * Deselect all options in multiple select tag.
-     *
-     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
-     */
     public function deselectAll()
     {
         if (!$this->isMultiple()) {
@@ -231,12 +176,6 @@ class WebDriverSelect
         }
     }
 
-    /**
-     * Deselect the option at the given index.
-     *
-     * @param int $index The index of the option. (0-based)
-     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
-     */
     public function deselectByIndex($index)
     {
         if (!$this->isMultiple()) {
@@ -252,15 +191,6 @@ class WebDriverSelect
         }
     }
 
-    /**
-     * Deselect all options that have value attribute matching the argument. That
-     * is, when given "foo" this would deselect an option like:
-     *
-     * <option value="foo">Bar</option>;
-     *
-     * @param string $value The value to match against.
-     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
-     */
     public function deselectByValue($value)
     {
         if (!$this->isMultiple()) {
@@ -274,15 +204,6 @@ class WebDriverSelect
         }
     }
 
-    /**
-     * Deselect all options that display text matching the argument. That is, when
-     * given "Bar" this would deselect an option like:
-     *
-     * <option value="foo">Bar</option>;
-     *
-     * @param string $text The visible text to match against.
-     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
-     */
     public function deselectByVisibleText($text)
     {
         if (!$this->isMultiple()) {
@@ -296,15 +217,6 @@ class WebDriverSelect
         }
     }
 
-    /**
-     * Deselect all options that display text matching the argument. That is, when
-     * given "Bar" this would deselect an option like:
-     *
-     * <option value="foo">Foo Bar Baz</option>;
-     *
-     * @param string $text The visible text to match against.
-     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
-     */
     public function deselectByVisiblePartialText($text)
     {
         if (!$this->isMultiple()) {

--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -40,9 +40,7 @@ class WebDriverSelect
     }
 
     /**
-     * @return bool Whether this select element support selecting multiple
-     *              options. This is done by checking the value of the 'multiple'
-     *              attribute.
+     * @return bool Whether this select element support selecting multiple options.
      */
     public function isMultiple()
     {
@@ -87,26 +85,6 @@ class WebDriverSelect
         }
 
         throw new NoSuchElementException('No options are selected');
-    }
-
-    /**
-     * Deselect all options in multiple select tag.
-     *
-     * @throws UnsupportedOperationException
-     */
-    public function deselectAll()
-    {
-        if (!$this->isMultiple()) {
-            throw new UnsupportedOperationException(
-                'You may only deselect all options of a multi-select'
-            );
-        }
-
-        foreach ($this->getOptions() as $option) {
-            if ($option->isSelected()) {
-                $option->click();
-            }
-        }
     }
 
     /**
@@ -253,6 +231,24 @@ class WebDriverSelect
     }
 
     /**
+     * Deselect all options in multiple select tag.
+     *
+     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
+     */
+    public function deselectAll()
+    {
+        if (!$this->isMultiple()) {
+            throw new UnsupportedOperationException('You may only deselect all options of a multi-select');
+        }
+
+        foreach ($this->getOptions() as $option) {
+            if ($option->isSelected()) {
+                $option->click();
+            }
+        }
+    }
+
+    /**
      * Deselect the option at the given index.
      *
      * @param int $index The index of the option. (0-based)
@@ -268,7 +264,7 @@ class WebDriverSelect
 
     /**
      * Deselect all options that have value attribute matching the argument. That
-     * is, when given "foo" this would select an option like:
+     * is, when given "foo" this would deselect an option like:
      *
      * <option value="foo">Bar</option>;
      *
@@ -287,7 +283,7 @@ class WebDriverSelect
 
     /**
      * Deselect all options that display text matching the argument. That is, when
-     * given "Bar" this would select an option like:
+     * given "Bar" this would deselect an option like:
      *
      * <option value="foo">Bar</option>;
      *
@@ -296,6 +292,30 @@ class WebDriverSelect
     public function deselectByVisibleText($text)
     {
         $xpath = './/option[normalize-space(.) = ' . $this->escapeQuotes($text) . ']';
+        $options = $this->element->findElements(WebDriverBy::xpath($xpath));
+        foreach ($options as $option) {
+            if ($option->isSelected()) {
+                $option->click();
+            }
+        }
+    }
+
+    /**
+     * Deselect all options that display text matching the argument. That is, when
+     * given "Bar" this would deselect an option like:
+     *
+     * <option value="foo">Foo Bar Baz</option>;
+     *
+     * @param string $text The visible text to match against.
+     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
+     */
+    public function deselectByVisiblePartialText($text)
+    {
+        if (!$this->isMultiple()) {
+            throw new UnsupportedOperationException('You may only deselect options of a multi-select');
+        }
+
+        $xpath = './/option[contains(normalize-space(.), ' . $this->escapeQuotes($text) . ')]';
         $options = $this->element->findElements(WebDriverBy::xpath($xpath));
         foreach ($options as $option) {
             if ($option->isSelected()) {

--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -97,23 +97,17 @@ class WebDriverSelect
      */
     public function selectByIndex($index)
     {
-        $matched = false;
         foreach ($this->getOptions() as $option) {
             if ($option->getAttribute('index') === (string) $index) {
                 if (!$option->isSelected()) {
                     $option->click();
-                    if (!$this->isMultiple()) {
-                        return;
-                    }
                 }
-                $matched = true;
+
+                return;
             }
         }
-        if (!$matched) {
-            throw new NoSuchElementException(
-                sprintf('Cannot locate option with index: %d', $index)
-            );
-        }
+
+        throw new NoSuchElementException(sprintf('Cannot locate option with index: %d', $index));
     }
 
     /**
@@ -262,8 +256,12 @@ class WebDriverSelect
         }
 
         foreach ($this->getOptions() as $option) {
-            if ($option->getAttribute('index') === (string) $index && $option->isSelected()) {
-                $option->click();
+            if ($option->getAttribute('index') === (string) $index) {
+                if ($option->isSelected()) {
+                    $option->click();
+                }
+
+                return;
             }
         }
     }

--- a/lib/WebDriverSelectInterface.php
+++ b/lib/WebDriverSelectInterface.php
@@ -1,0 +1,127 @@
+<?php
+namespace Facebook\WebDriver;
+
+use Facebook\WebDriver\Exception\NoSuchElementException;
+use Facebook\WebDriver\Exception\UnsupportedOperationException;
+
+/**
+ * Models an element of select type, providing helper methods to select and deselect options.
+ */
+interface WebDriverSelectInterface
+{
+    /**
+     * @return bool Whether this select element support selecting multiple options.
+     */
+    public function isMultiple();
+
+    /**
+     * @return WebDriverElement[] All options belonging to this select tag.
+     */
+    public function getOptions();
+
+    /**
+     * @return WebDriverElement[] All selected options belonging to this select tag.
+     */
+    public function getAllSelectedOptions();
+
+    /**
+     * @throws NoSuchElementException
+     *
+     * @return WebDriverElement The first selected option in this select tag (or
+     *                          the currently selected option in a normal select)
+     */
+    public function getFirstSelectedOption();
+
+    /**
+     * Select the option at the given index.
+     *
+     * @param int $index The index of the option. (0-based)
+     *
+     * @throws NoSuchElementException
+     */
+    public function selectByIndex($index);
+
+    /**
+     * Select all options that have value attribute matching the argument. That is, when given "foo" this would
+     * select an option like:
+     *
+     * <option value="foo">Bar</option>;
+     *
+     * @param string $value The value to match against.
+     *
+     * @throws NoSuchElementException
+     */
+    public function selectByValue($value);
+
+    /**
+     * Select all options that display text matching the argument. That is, when given "Bar" this would
+     * select an option like:
+     *
+     * <option value="foo">Bar</option>;
+     *
+     * @param string $text The visible text to match against.
+     *
+     * @throws NoSuchElementException
+     */
+    public function selectByVisibleText($text);
+
+    /**
+     * Select all options that display text partially matching the argument. That is, when given "Bar" this would
+     * select an option like:
+     *
+     * <option value="bar">Foo Bar Baz</option>;
+     *
+     * @param string $text The visible text to match against.
+     *
+     * @throws NoSuchElementException
+     */
+    public function selectByVisiblePartialText($text);
+
+    /**
+     * Deselect all options in multiple select tag.
+     *
+     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
+     */
+    public function deselectAll();
+
+    /**
+     * Deselect the option at the given index.
+     *
+     * @param int $index The index of the option. (0-based)
+     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
+     */
+    public function deselectByIndex($index);
+
+    /**
+     * Deselect all options that have value attribute matching the argument. That is, when given "foo" this would
+     * deselect an option like:
+     *
+     * <option value="foo">Bar</option>;
+     *
+     * @param string $value The value to match against.
+     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
+     */
+    public function deselectByValue($value);
+
+    /**
+     * Deselect all options that display text matching the argument. That is, when given "Bar" this would
+     * deselect an option like:
+     *
+     * <option value="foo">Bar</option>;
+     *
+     * @param string $text The visible text to match against.
+     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
+     */
+    public function deselectByVisibleText($text);
+
+    /**
+     * Deselect all options that display text matching the argument. That is, when given "Bar" this would
+     * deselect an option like:
+     *
+     * <option value="foo">Foo Bar Baz</option>;
+     *
+     * @param string $text The visible text to match against.
+     * @throws UnsupportedOperationException If the SELECT does not support multiple selections
+     */
+    public function deselectByVisiblePartialText($text);
+}

--- a/tests/functional/WebDriverSelectTest.php
+++ b/tests/functional/WebDriverSelectTest.php
@@ -1,0 +1,390 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Facebook\WebDriver;
+
+use Facebook\WebDriver\Exception\NoSuchElementException;
+use Facebook\WebDriver\Exception\UnexpectedTagNameException;
+use Facebook\WebDriver\Exception\UnsupportedOperationException;
+
+/**
+ * @covers Facebook\WebDriver\WebDriverSelect
+ * @covers Facebook\WebDriver\Exception\UnexpectedTagNameException
+ */
+class WebDriverSelectTest extends WebDriverTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->driver->get($this->getTestPath('form.html'));
+    }
+
+    public function testShouldCreateNewInstanceForSelectElementAndDetectIfItIsMultiple()
+    {
+        $originalElement = $this->driver->findElement(WebDriverBy::cssSelector('#select'));
+        $originalMultipleElement = $this->driver->findElement(WebDriverBy::cssSelector('#select-multiple'));
+
+        $select = new WebDriverSelect($originalElement);
+        $selectMultiple = new WebDriverSelect($originalMultipleElement);
+
+        $this->assertInstanceOf(WebDriverSelect::class, $select);
+        $this->assertFalse($select->isMultiple());
+
+        $this->assertInstanceOf(WebDriverSelect::class, $selectMultiple);
+        $this->assertTrue($selectMultiple->isMultiple());
+    }
+
+    public function testShouldThrowExceptionWhenNotInstantiatedOnSelectElement()
+    {
+        $notSelectElement = $this->driver->findElement(WebDriverBy::cssSelector('textarea'));
+
+        $this->setExpectedException(
+            UnexpectedTagNameException::class,
+            'Element should have been "select" but was "textarea"'
+        );
+        new WebDriverSelect($notSelectElement);
+    }
+
+    /**
+     * @dataProvider selectSelectorProvider
+     * @param string $selector
+     */
+    public function testShouldGetOptionsOfSelect($selector)
+    {
+        $originalElement = $this->driver->findElement(WebDriverBy::cssSelector($selector));
+        $select = new WebDriverSelect($originalElement);
+
+        $options = $select->getOptions();
+
+        $this->assertContainsOnlyInstancesOf(WebDriverElement::class, $options);
+        $this->assertCount(5, $options);
+    }
+
+    public function selectSelectorProvider()
+    {
+        return [
+            'simple <select>' => ['#select'],
+            '<select> with multiple attribute' => ['#select-multiple'],
+        ];
+    }
+
+    public function testShouldDefaultSelectedOptionOfSimpleSelect()
+    {
+        $select = $this->getWebDriverSelectForSimpleSelect();
+
+        $selectedOptions = $select->getAllSelectedOptions();
+        $firstSelectedOption = $select->getFirstSelectedOption();
+
+        $this->assertContainsOnlyInstancesOf(WebDriverElement::class, $selectedOptions);
+        $this->assertCount(1, $selectedOptions);
+        $this->assertSame('First', $selectedOptions[0]->getText());
+
+        $this->assertInstanceOf(WebDriverElement::class, $firstSelectedOption);
+        $this->assertSame('First', $firstSelectedOption->getText());
+    }
+
+    public function testShouldReturnEmptyArrayIfNoOptionsOfMultipleSelectSelected()
+    {
+        $select = $this->getWebDriverSelectForMultipleSelect();
+
+        $selectedOptions = $select->getAllSelectedOptions();
+
+        $this->assertSame([], $selectedOptions);
+    }
+
+    public function testShouldThrowExceptionIfThereIsNoFirstSelectedOptionOfMultipleSelect()
+    {
+        $select = $this->getWebDriverSelectForMultipleSelect();
+
+        $this->setExpectedException(
+            NoSuchElementException::class,
+            'No options are selected'
+        );
+        $select->getFirstSelectedOption();
+    }
+
+    public function testShouldSelectOptionOfSimpleSelectByIndex()
+    {
+        $select = $this->getWebDriverSelectForSimpleSelect();
+        $this->assertSame('first', $select->getFirstSelectedOption()->getAttribute('value'));
+
+        $select->selectByIndex(1);
+        $select->selectByIndex(1); // should be selected even if selected again
+        $this->assertSame('second', $select->getFirstSelectedOption()->getAttribute('value'));
+
+        $select->selectByIndex(3);
+        $this->assertSame('fourth', $select->getFirstSelectedOption()->getAttribute('value'));
+    }
+
+    public function testShouldSelectOptionOfMultipleSelectByIndex()
+    {
+        $select = $this->getWebDriverSelectForMultipleSelect();
+        $this->assertSame([], $select->getAllSelectedOptions());
+
+        $select->selectByIndex(1);
+        $select->selectByIndex(1); // should be selected even if selected again
+        $this->assertSame('second', $select->getFirstSelectedOption()->getAttribute('value'));
+        $this->assertContainsOptionsWithValues(['second'], $select->getAllSelectedOptions());
+
+        $select->selectByIndex(4);
+        $select->selectByIndex(3);
+        // the first selected option is still the same
+        $this->assertSame('second', $select->getFirstSelectedOption()->getAttribute('value'));
+
+        $this->assertContainsOptionsWithValues(['second', 'fourth', 'fifth'], $select->getAllSelectedOptions());
+    }
+
+    public function testShouldThrowExceptionIfThereIsNoOptionIndexToSelect()
+    {
+        $select = $this->getWebDriverSelectForSimpleSelect();
+
+        $this->setExpectedException(
+            NoSuchElementException::class,
+            'Cannot locate option with index: 1337'
+        );
+        $select->selectByIndex(1337);
+    }
+
+    public function testShouldSelectOptionOfSimpleSelectByValue()
+    {
+        $select = $this->getWebDriverSelectForSimpleSelect();
+        $this->assertSame('first', $select->getFirstSelectedOption()->getAttribute('value'));
+
+        $select->selectByValue('second');
+        $select->selectByValue('second'); // should be selected even if selected again
+        $this->assertSame('second', $select->getFirstSelectedOption()->getAttribute('value'));
+
+        $select->selectByValue('fourth');
+        $this->assertSame('fourth', $select->getFirstSelectedOption()->getAttribute('value'));
+    }
+
+    public function testShouldSelectOptionOfMultipleSelectByValue()
+    {
+        $select = $this->getWebDriverSelectForMultipleSelect();
+        $this->assertSame([], $select->getAllSelectedOptions());
+
+        $select->selectByValue('second');
+        $select->selectByValue('second'); // should be selected even if selected again
+        $this->assertSame('second', $select->getFirstSelectedOption()->getAttribute('value'));
+        $this->assertContainsOptionsWithValues(['second'], $select->getAllSelectedOptions());
+
+        $select->selectByValue('fifth');
+        $select->selectByValue('fourth');
+        // the first selected option is still the same
+        $this->assertSame('second', $select->getFirstSelectedOption()->getAttribute('value'));
+
+        $this->assertContainsOptionsWithValues(['second', 'fourth', 'fifth'], $select->getAllSelectedOptions());
+    }
+
+    public function testShouldThrowExceptionIfThereIsNoOptionValueToSelect()
+    {
+        $select = $this->getWebDriverSelectForSimpleSelect();
+
+        $this->setExpectedException(
+            NoSuchElementException::class,
+            'Cannot locate option with value: 1337'
+        );
+        $select->selectByValue(1337);
+    }
+
+    public function testShouldSelectOptionOfSimpleSelectByVisibleText()
+    {
+        $select = $this->getWebDriverSelectForSimpleSelect();
+        $this->assertSame('first', $select->getFirstSelectedOption()->getAttribute('value'));
+
+        $select->selectByVisibleText('Fourth with spaces inside');
+        $select->selectByVisibleText('Fourth with spaces inside'); // should be selected even if selected again
+        $this->assertSame('fourth', $select->getFirstSelectedOption()->getAttribute('value'));
+
+        $select->selectByVisibleText('Fifth surrounded by spaces');
+        $this->assertSame('fifth', $select->getFirstSelectedOption()->getAttribute('value'));
+    }
+
+    public function testShouldSelectOptionOfMultipleSelectByVisibleText()
+    {
+        $select = $this->getWebDriverSelectForMultipleSelect();
+        $this->assertSame([], $select->getAllSelectedOptions());
+
+        $select->selectByVisibleText('This is second option');
+        $select->selectByVisibleText('This is second option');  // should be selected even if selected again
+        $this->assertSame('second', $select->getFirstSelectedOption()->getAttribute('value'));
+        $this->assertContainsOptionsWithValues(['second'], $select->getAllSelectedOptions());
+
+        $select->selectByVisibleText('Fifth surrounded by spaces');
+        $select->selectByVisibleText('Fourth with spaces inside');
+        // the first selected option is still the same
+        $this->assertSame('second', $select->getFirstSelectedOption()->getAttribute('value'));
+
+        $this->assertContainsOptionsWithValues(['second', 'fourth', 'fifth'], $select->getAllSelectedOptions());
+    }
+
+    public function testShouldThrowExceptionIfThereIsNoOptionVisibleTextToSelect()
+    {
+        $select = $this->getWebDriverSelectForSimpleSelect();
+
+        $this->setExpectedException(
+            NoSuchElementException::class,
+            'Cannot locate option with text: second'
+        );
+        $select->selectByVisibleText('second'); // the option is "This is second option"
+    }
+
+    public function testShouldSelectOptionOfSimpleSelectByVisiblePartialText()
+    {
+        $select = $this->getWebDriverSelectForSimpleSelect();
+        $this->assertSame('first', $select->getFirstSelectedOption()->getAttribute('value'));
+
+        $select->selectByVisiblePartialText('not second');
+        $this->assertSame('third', $select->getFirstSelectedOption()->getAttribute('value'));
+
+        $select->selectByVisiblePartialText('Fourth with spaces');
+        $select->selectByVisiblePartialText('Fourth with spaces'); // should be selected even if selected again
+        $this->assertSame('fourth', $select->getFirstSelectedOption()->getAttribute('value'));
+    }
+
+    public function testShouldSelectOptionOfMultipleSelectByVisiblePartialText()
+    {
+        $select = $this->getWebDriverSelectForMultipleSelect();
+        $this->assertSame([], $select->getAllSelectedOptions());
+
+        $select->selectByVisiblePartialText('Firs');
+        $select->selectByVisiblePartialText('Firs'); // should be selected even if selected again
+        $this->assertSame('first', $select->getFirstSelectedOption()->getAttribute('value'));
+        $this->assertContainsOptionsWithValues(['first'], $select->getAllSelectedOptions());
+
+        $select->selectByVisiblePartialText('second'); // matches options 'second' and 'third'
+        $select->selectByVisiblePartialText('Fourth with spaces');
+        // the first selected option is still the same
+        $this->assertSame('first', $select->getFirstSelectedOption()->getAttribute('value'));
+
+        $this->assertContainsOptionsWithValues(
+            ['first', 'second', 'third', 'fourth'],
+            $select->getAllSelectedOptions()
+        );
+    }
+
+    public function testShouldThrowExceptionIfThereIsNoOptionVisiblePartialTextToSelect()
+    {
+        $select = $this->getWebDriverSelectForSimpleSelect();
+
+        $this->setExpectedException(
+            NoSuchElementException::class,
+            'Cannot locate option with text: Not existing option'
+        );
+        $select->selectByVisiblePartialText('Not existing option');
+    }
+
+    public function testShouldThrowExceptionWhenDeselectingOnSimpleSelect()
+    {
+        $select = $this->getWebDriverSelectForSimpleSelect();
+
+        $this->setExpectedException(
+            UnsupportedOperationException::class,
+            'You may only deselect all options of a multi-select'
+        );
+        $select->deselectAll();
+    }
+
+    public function testShouldDeselectAllOptionsOnMultipleSelect()
+    {
+        $select = $this->getWebDriverSelectForMultipleSelect();
+
+        $select->selectByIndex(1);
+        $select->selectByIndex(3);
+        $select->selectByIndex(4);
+        $this->assertCount(3, $select->getAllSelectedOptions());
+
+        $select->deselectAll();
+
+        $this->assertCount(0, $select->getAllSelectedOptions());
+    }
+
+    public function testShouldDeselectOptionByIndex()
+    {
+        $select = $this->getWebDriverSelectForMultipleSelect();
+        $select->selectByValue('fourth'); // index 3
+        $select->selectByValue('second'); // index 1
+
+        $select->deselectByIndex(3);
+        $select->deselectByIndex(3); // should be deselected even if deselected again
+        $select->deselectByIndex(4); // should not select unselected option
+
+        $this->assertContainsOptionsWithValues(['second'], $select->getAllSelectedOptions());
+    }
+
+    public function testShouldDeselectOptionByValue()
+    {
+        $select = $this->getWebDriverSelectForMultipleSelect();
+        $select->selectByValue('third');
+        $select->selectByValue('first');
+
+        $select->deselectByValue('third');
+        $select->deselectByValue('third'); // should be deselected even if deselected again
+        $select->deselectByValue('second'); // should not select unselected option
+
+        $this->assertContainsOptionsWithValues(['first'], $select->getAllSelectedOptions());
+    }
+
+    public function testShouldDeselectOptionByVisibleText()
+    {
+        $select = $this->getWebDriverSelectForMultipleSelect();
+        $select->selectByValue('fourth'); // text 'Fourth  with   spaces   inside'
+        $select->selectByValue('fifth'); // text '   Fifth surrounded by spaces    '
+        $select->selectByValue('second'); // text 'This is second option'
+
+        $select->deselectByVisibleText('Fourth with spaces inside');
+        $select->deselectByVisibleText('Fourth with spaces inside'); // should be deselected even if deselected again
+        $select->deselectByVisibleText('Fifth surrounded by spaces');
+        $select->deselectByVisibleText('First'); // should not select unselected option
+
+        $this->assertContainsOptionsWithValues(['second'], $select->getAllSelectedOptions());
+    }
+
+    /**
+     * @return WebDriverSelect
+     */
+    protected function getWebDriverSelectForSimpleSelect()
+    {
+        $originalElement = $this->driver->findElement(WebDriverBy::cssSelector('#select'));
+
+        return new WebDriverSelect($originalElement);
+    }
+
+    /**
+     * @return WebDriverSelect
+     */
+    protected function getWebDriverSelectForMultipleSelect()
+    {
+        $originalElement = $this->driver->findElement(WebDriverBy::cssSelector('#select-multiple'));
+
+        return new WebDriverSelect($originalElement);
+    }
+
+    /**
+     * @param string[] $expectedValues
+     * @param array $options
+     */
+    private function assertContainsOptionsWithValues(array $expectedValues, array $options)
+    {
+        $expectedCount = count($expectedValues);
+        $this->assertContainsOnlyInstancesOf(WebDriverElement::class, $options);
+        $this->assertCount($expectedCount, $options);
+
+        for ($i = 0; $i < $expectedCount; $i++) {
+            $this->assertSame($expectedValues[$i], $options[$i]->getAttribute('value'));
+        }
+    }
+}

--- a/tests/functional/WebDriverSelectTest.php
+++ b/tests/functional/WebDriverSelectTest.php
@@ -353,6 +353,38 @@ class WebDriverSelectTest extends WebDriverTestCase
         $this->assertContainsOptionsWithValues(['second'], $select->getAllSelectedOptions());
     }
 
+    public function testShouldDeselectOptionByVisiblePartialText()
+    {
+        $select = $this->getWebDriverSelectForMultipleSelect();
+        $select->selectByValue('fourth'); // text 'Fourth  with   spaces   inside'
+        $select->selectByValue('fifth'); // text '   Fifth surrounded by spaces    '
+        $select->selectByValue('second'); // text 'This is second option'
+        $select->selectByValue('third'); // text 'This is not second option'
+        $select->selectByValue('first'); // text 'First'
+        $this->assertCount(5, $select->getAllSelectedOptions());
+
+        $select->deselectByVisiblePartialText('second'); // should deselect two options
+        $this->assertContainsOptionsWithValues(['first', 'fourth', 'fifth'], $select->getAllSelectedOptions());
+
+        $select->deselectByVisiblePartialText('Fourth with spaces');
+        $select->deselectByVisiblePartialText('Fourth with spaces'); // should be deselected even if deselected again
+        $this->assertContainsOptionsWithValues(['first', 'fifth'], $select->getAllSelectedOptions());
+
+        $select->deselectByVisiblePartialText('Fifth surrounded');
+        $this->assertContainsOptionsWithValues(['first'], $select->getAllSelectedOptions());
+    }
+
+    public function testShouldThrowExceptionIfDeselectingSimpleSelectByVisiblePartialText()
+    {
+        $select = $this->getWebDriverSelectForSimpleSelect();
+
+        $this->setExpectedException(
+            UnsupportedOperationException::class,
+            'You may only deselect options of a multi-select'
+        );
+        $select->deselectByVisiblePartialText('First');
+    }
+
     /**
      * @return WebDriverSelect
      */

--- a/tests/functional/WebDriverSelectTest.php
+++ b/tests/functional/WebDriverSelectTest.php
@@ -325,6 +325,17 @@ class WebDriverSelectTest extends WebDriverTestCase
         $this->assertContainsOptionsWithValues(['second'], $select->getAllSelectedOptions());
     }
 
+    public function testShouldThrowExceptionIfDeselectingSimpleSelectByIndex()
+    {
+        $select = $this->getWebDriverSelectForSimpleSelect();
+
+        $this->setExpectedException(
+            UnsupportedOperationException::class,
+            'You may only deselect options of a multi-select'
+        );
+        $select->deselectByIndex(0);
+    }
+
     public function testShouldDeselectOptionByValue()
     {
         $select = $this->getWebDriverSelectForMultipleSelect();
@@ -336,6 +347,17 @@ class WebDriverSelectTest extends WebDriverTestCase
         $select->deselectByValue('second'); // should not select unselected option
 
         $this->assertContainsOptionsWithValues(['first'], $select->getAllSelectedOptions());
+    }
+
+    public function testShouldThrowExceptionIfDeselectingSimpleSelectByValue()
+    {
+        $select = $this->getWebDriverSelectForSimpleSelect();
+
+        $this->setExpectedException(
+            UnsupportedOperationException::class,
+            'You may only deselect options of a multi-select'
+        );
+        $select->deselectByValue('first');
     }
 
     public function testShouldDeselectOptionByVisibleText()
@@ -351,6 +373,17 @@ class WebDriverSelectTest extends WebDriverTestCase
         $select->deselectByVisibleText('First'); // should not select unselected option
 
         $this->assertContainsOptionsWithValues(['second'], $select->getAllSelectedOptions());
+    }
+
+    public function testShouldThrowExceptionIfDeselectingSimpleSelectByVisibleText()
+    {
+        $select = $this->getWebDriverSelectForSimpleSelect();
+
+        $this->setExpectedException(
+            UnsupportedOperationException::class,
+            'You may only deselect options of a multi-select'
+        );
+        $select->deselectByVisibleText('First');
     }
 
     public function testShouldDeselectOptionByVisiblePartialText()

--- a/tests/functional/web/form.html
+++ b/tests/functional/web/form.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>php-webdriver form test page</title>
+</head>
+<body>
+    <form>
+        <label>
+            Text:
+            <input type="text" name="text" id="text"/>
+        </label>
+        <br>
+
+        <label>
+            Textarea:
+            <textarea name="textarea" id="textarea"></textarea>
+        </label>
+        <br>
+
+        <label for="select">Select one:</label>
+        <select name="select" id="select">
+            <option value="first">First</option>
+            <option value="second">This is second option</option>
+            <option value="third">This is not second option</option>
+            <option value="fourth">Fourth  with   spaces   inside</option>
+            <option value="fifth">   Fifth surrounded by spaces    </option>
+        </select>
+        <br>
+
+        <label for="select-multiple">Select multiple:</label>
+        <select name="select-multiple" id="select-multiple" multiple>
+            <option value="first">First</option>
+            <option value="second">This is second option</option>
+            <option value="third">This is not second option</option>
+            <option value="fourth">Fourth  with   spaces   inside</option>
+            <option value="fifth">   Fifth surrounded by spaces    </option>
+        </select>
+        <br>
+
+        <p>
+            <input type="submit" name="submit" id="submit" value="Submit">
+        </p>
+
+
+    </form>
+</body>
+</html>

--- a/tests/unit/Support/XPathEscaperTest.php
+++ b/tests/unit/Support/XPathEscaperTest.php
@@ -1,0 +1,49 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Facebook\WebDriver\Support;
+
+class XPathEscaperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider xpathProvider
+     * @param string $input
+     * @param string $expectedOutput
+     */
+    public function testShouldInstantiateWithCapabilitiesGivenInConstructor($input, $expectedOutput)
+    {
+        $output = XPathEscaper::escapeQuotes($input);
+
+        $this->assertSame($expectedOutput, $output);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function xpathProvider()
+    {
+        return [
+            'empty string encapsulate in single quotes' => ['', "''"],
+            'string without quotes encapsulate in single quotes' => ['foo bar', "'foo bar'"],
+            'string with single quotes encapsulate in double quotes' => ['foo\'bar\'', '"foo\'bar\'"'],
+            'string with double quotes encapsulate in single quotes' => ['foo"bar"', '\'foo"bar"\''],
+            'string with both types of quotes concatenate' => ['\'"', "concat('', \"'\" ,'\"')"],
+            'string with multiple both types of quotes concatenate' => [
+                'a \'b\'"c"',
+                "concat('a ', \"'\" ,'b', \"'\" ,'\"c\"')",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
- Replaces #376, fixes #375, also adds `deselectByVisiblePartialText` method as a counterpart to the new `selectByVisiblePartialText`
- Functional tests for all WebDriverSelect methods were added
- XPath escaping which was present wasn't actually working (though nobody notices it for ages 🤔), not it should be and could by also called from user scripts
- Some refactoring and DRY
