### PR TITLE
fix php docs for getText

### DIFF
--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -262,7 +262,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
 
     /**
      * Get the visible (i.e. not hidden by CSS) innerText of this element,
-     * including sub-elements, without any leading or trailing whitespace.
+     * including sub-elements.
      *
      * @return string The visible innerText of this element.
      */


### PR DESCRIPTION
The getText return the real value with whitespaces leading and trailing. See also https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol