### PR TITLE
Optimize getAllSelectedOptions method for single select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 - Deprecated `setSessionID()` and `setCommandExecutor()` methods of `RemoteWebDriver` class; these values should be immutable and thus passed only via constructor.
 - Deprecated `WebDriverExpectedCondition::textToBePresentInElement()` in favor of `elementTextContains()`
 - Throw an exception when attempting to deselect options of non-multiselect (it already didn't have any effect, but was silently ignored).
+- Optimize performance of `(de)selectByIndex()` and `getAllSelectedOptions()` methods of `WebDriverSelect` when used with non-multiple select element.
 
 ### Fixed
 - XPath escaping in `select*()` and `deselect*()` methods of `WebDriverSelect`.

--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -58,6 +58,10 @@ class WebDriverSelect implements WebDriverSelectInterface
         foreach ($this->getOptions() as $option) {
             if ($option->isSelected()) {
                 $selected_options[] = $option;
+
+                if (!$this->isMultiple()) {
+                    return $selected_options;
+                }
             }
         }
 


### PR DESCRIPTION
Single select always contains exactly only one selected option.