### PR TITLE
Added ext-zip to require section of composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
   "require": {
     "php": "^5.5 || ~7.0",
     "symfony/process": "^2.8 || ^3.1",
-    "ext-curl": "*"
+    "ext-curl": "*",
+    "ext-zip: "*"
   },
   "require-dev": {
     "phpunit/phpunit": "4.6.* || ~5.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "php": "^5.5 || ~7.0",
     "symfony/process": "^2.8 || ^3.1",
     "ext-curl": "*",
-    "ext-zip: "*"
+    "ext-zip": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "4.6.* || ~5.0",


### PR DESCRIPTION
While trying to run this example (https://github.com/facebook/php-webdriver/wiki/upload-a-file) I ran into a problem of ZipArchive class not being found. Fixed it by doing `sudo apt-get install php7.1-zip`