### PR TITLE
Deprecate isJavascriptEnabled method of WebDriverCapabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 - Cookies should now be set using `Cookie` value object instead of an array when passed to to `addCookie()` method of `WebDriverOptions`.
 - Cookies retrieved using `getCookieNamed()` and `getCookies()` methods of `WebDriverOptions` are now encapsulated in `Cookie` object instead of an plain array. The object implements `ArrayAccess` interface to provide backward compatibility.
 - `ext-zip` is now specified as required dependency in composer.json (but the extension was already required by the code, though).
+- Deprecate `WebDriverCapabilities::isJavascriptEnabled()` method.
 
 ### Fixed
 - Do not throw fatal error when `null` is passed to `sendKeys()`.

--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -123,6 +123,8 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
+     * @todo Remove in next major release (BC)
+     * @deprecated All browsers are always JS enabled except HtmlUnit and it's not meaningful to disable JS execution.
      * @return bool Whether javascript is enabled.
      */
     public function isJavascriptEnabled()

--- a/lib/WebDriverCapabilities.php
+++ b/lib/WebDriverCapabilities.php
@@ -45,6 +45,8 @@ interface WebDriverCapabilities
     public function is($capability_name);
 
     /**
+     * @todo Remove in next major release (BC)
+     * @deprecated All browsers are always JS enabled except HtmlUnit and it's not meaningful to disable JS execution.
      * @return bool Whether javascript is enabled.
      */
     public function isJavascriptEnabled();


### PR DESCRIPTION
It was deprecated in the Java client version 3.3.1 as well.

See https://github.com/SeleniumHQ/selenium/commit/5b0f88ef3256595148b357dec6209735cab25bea