### PR TITLE
Deprecate text to be present in element value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 - Cookies retrieved using `getCookieNamed()` and `getCookies()` methods of `WebDriverOptions` are now encapsulated in `Cookie` object instead of an plain array. The object implements `ArrayAccess` interface to provide backward compatibility.
 - `ext-zip` is now specified as required dependency in composer.json (but the extension was already required by the code, though).
 - Deprecate `WebDriverCapabilities::isJavascriptEnabled()` method.
+- Deprecate `textToBePresentInElementValue` expected condition in favor of `elementValueContains`.
 
 ### Fixed
 - Do not throw fatal error when `null` is passed to `sendKeys()`.

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -292,11 +292,25 @@ class WebDriverExpectedCondition
     /**
      * An expectation for checking if the given text is present in the specified elements value attribute.
      *
+     * @codeCoverageIgnore
+     * @deprecated Use WebDriverExpectedCondition::elementValueContains() instead
      * @param WebDriverBy $by The locator used to find the element.
      * @param string $text The text to be presented in the element value.
      * @return WebDriverExpectedCondition<bool> Condition returns whether the text is present in value attribute.
      */
     public static function textToBePresentInElementValue(WebDriverBy $by, $text)
+    {
+        return self::elementValueContains($by, $text);
+    }
+
+    /**
+     * An expectation for checking if the given text is present in the specified elements value attribute.
+     *
+     * @param WebDriverBy $by The locator used to find the element.
+     * @param string $text The text to be presented in the element value.
+     * @return WebDriverExpectedCondition<bool> Condition returns whether the text is present in value attribute.
+     */
+    public static function elementValueContains(WebDriverBy $by, $text)
     {
         return new static(
             function (WebDriver $driver) use ($by, $text) {

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -185,6 +185,73 @@ class WebDriverExpectedConditionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($element, $this->wait->until($condition));
     }
 
+    public function testShouldDetectInvisibilityOfElementLocatedConditionOnNoSuchElementException()
+    {
+        $element = $this->createRemoteWebElementMock();
+
+        $this->driverMock->expects($this->at(0))
+            ->method('findElement')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willReturn($element);
+
+        $element->expects($this->at(0))
+            ->method('isDisplayed')
+            ->willReturn(true);
+
+        $this->driverMock->expects($this->at(1))
+            ->method('findElement')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willThrowException(new NoSuchElementException(''));
+
+        $condition = WebDriverExpectedCondition::invisibilityOfElementLocated(WebDriverBy::cssSelector('.foo'));
+
+        $this->assertTrue($this->wait->until($condition));
+    }
+
+    public function testShouldDetectInvisibilityOfElementLocatedConditionOnStaleElementReferenceException()
+    {
+        $element = $this->createRemoteWebElementMock();
+
+        $this->driverMock->expects($this->exactly(2))
+            ->method('findElement')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willReturn($element);
+
+        $element->expects($this->at(0))
+            ->method('isDisplayed')
+            ->willReturn(true);
+
+        $element->expects($this->at(1))
+            ->method('isDisplayed')
+            ->willThrowException(new StaleElementReferenceException(''));
+
+        $condition = WebDriverExpectedCondition::invisibilityOfElementLocated(WebDriverBy::cssSelector('.foo'));
+
+        $this->assertTrue($this->wait->until($condition));
+    }
+
+    public function testShouldDetectInvisibilityOfElementLocatedConditionWhenElementBecamesInvisible()
+    {
+        $element = $this->createRemoteWebElementMock();
+
+        $this->driverMock->expects($this->exactly(2))
+            ->method('findElement')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willReturn($element);
+
+        $element->expects($this->at(0))
+            ->method('isDisplayed')
+            ->willReturn(true);
+
+        $element->expects($this->at(1))
+            ->method('isDisplayed')
+            ->willReturn(false);
+
+        $condition = WebDriverExpectedCondition::invisibilityOfElementLocated(WebDriverBy::cssSelector('.foo'));
+
+        $this->assertTrue($this->wait->until($condition));
+    }
+
     public function testShouldDetectVisibilityOfCondition()
     {
         $element = $this->createRemoteWebElementMock();

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -292,6 +292,41 @@ class WebDriverExpectedConditionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->wait->until($condition));
     }
 
+    public function testShouldDetectElementValueContainsCondition()
+    {
+        // Set-up the consecutive calls to apply() as follows:
+        // Call #1: throws NoSuchElementException
+        // Call #2: return Element, but getAttribute will throw StaleElementReferenceException
+        // Call #3: return Element, getAttribute('value') will return not-matching text
+        // Call #4: return Element, getAttribute('value') will return matching text
+
+        $element = $this->createRemoteWebElementMock();
+
+        $element->expects($this->at(0))
+            ->method('getAttribute')
+            ->with('value')
+            ->willThrowException(new StaleElementReferenceException(''));
+
+        $element->expects($this->at(1))
+            ->method('getAttribute')
+            ->with('value')
+            ->willReturn('wrong text');
+
+        $element->expects($this->at(2))
+            ->method('getAttribute')
+            ->with('value')
+            ->willReturn('matching text');
+
+        $this->setupDriverToReturnElementAfterAnException($element, 4);
+
+        $condition = WebDriverExpectedCondition::elementValueContains(
+            WebDriverBy::cssSelector('.foo'),
+            'matching'
+        );
+
+        $this->assertTrue($this->wait->until($condition));
+    }
+
     public function testShouldDetectNumberOfWindowsToBeCondition()
     {
         $this->driverMock->expects($this->any())


### PR DESCRIPTION
...  in favor of `elementValueContains()`. This makes the name consistent with other expected conditions.