### PR TITLE
Correct constant checking

### DIFF
--- a/lib/Net/URLChecker.php
+++ b/lib/Net/URLChecker.php
@@ -66,7 +66,7 @@ class URLChecker
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         // The PHP doc indicates that CURLOPT_CONNECTTIMEOUT_MS constant is added in cURL 7.16.2
         // available since PHP 5.2.3.
-        if (!defined(CURLOPT_CONNECTTIMEOUT_MS)) {
+        if (!defined('CURLOPT_CONNECTTIMEOUT_MS')) {
             define('CURLOPT_CONNECTTIMEOUT_MS', 156);  // default value for CURLOPT_CONNECTTIMEOUT_MS
         }
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, self::CONNECT_TIMEOUT_MS);


### PR DESCRIPTION
Prior to this change I would be getting `Constant CURLOPT_CONNECTTIMEOUT_MS already defined` since PHP would try to re-define a constant.