### PR TITLE
Drop PHP 5.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 dist: trusty
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- Drop PHP 5.5 support, the minimal required version of PHP is now PHP 5.6.
 
 ## 1.4.1 - 2017-04-28
 ### Fixed

--- a/lib/Support/Events/EventFiringWebDriver.php
+++ b/lib/Support/Events/EventFiringWebDriver.php
@@ -396,15 +396,14 @@ class EventFiringWebDriver implements WebDriver, JavaScriptExecutor
 
     /**
      * @param mixed $method
+     * @param mixed $arguments,...
      */
-    protected function dispatch($method)
+    protected function dispatch($method, ...$arguments)
     {
         if (!$this->dispatcher) {
             return;
         }
 
-        $arguments = func_get_args();
-        unset($arguments[0]);
         $this->dispatcher->dispatch($method, $arguments);
     }
 

--- a/lib/Support/Events/EventFiringWebDriverNavigation.php
+++ b/lib/Support/Events/EventFiringWebDriverNavigation.php
@@ -149,15 +149,14 @@ class EventFiringWebDriverNavigation
 
     /**
      * @param mixed $method
+     * @param mixed $arguments,...
      */
-    protected function dispatch($method)
+    protected function dispatch($method, ...$arguments)
     {
         if (!$this->dispatcher) {
             return;
         }
 
-        $arguments = func_get_args();
-        unset($arguments[0]);
         $this->dispatcher->dispatch($method, $arguments);
     }
 

--- a/lib/Support/Events/EventFiringWebElement.php
+++ b/lib/Support/Events/EventFiringWebElement.php
@@ -392,14 +392,14 @@ class EventFiringWebElement implements WebDriverElement, WebDriverLocatable
 
     /**
      * @param mixed $method
+     * @param mixed $arguments,...
      */
-    protected function dispatch($method)
+    protected function dispatch($method, ...$arguments)
     {
         if (!$this->dispatcher) {
             return;
         }
-        $arguments = func_get_args();
-        unset($arguments[0]);
+
         $this->dispatcher->dispatch($method, $arguments);
     }
 


### PR DESCRIPTION
Anyone against dropping support of PHP 5.5?

It blocks using some newer version of other libraries (PHPUnit etc.), is no longer officially supported [for over a year](http://php.net/eol.php) and its [usage also drops dramatically](https://seld.be/notes/php-versions-stats-2017-1-edition) in the last year.

Of course anyone relying on PHP 5.5 could still use all versions preceding the one which will contain this change, so I guess this should not by an issue for anyone.