### PR TITLE
Update platform capability to match the w3c spec

### DIFF
--- a/lib/Remote/WebDriverCapabilityType.php
+++ b/lib/Remote/WebDriverCapabilityType.php
@@ -23,6 +23,7 @@ class WebDriverCapabilityType
     const BROWSER_NAME = 'browserName';
     const VERSION = 'version';
     const PLATFORM = 'platform';
+    const PLATFORM_NAME = 'platformName';
     const JAVASCRIPT_ENABLED = 'javascriptEnabled';
     const TAKES_SCREENSHOT = 'takesScreenshot';
     const HANDLES_ALERTS = 'handlesAlerts';

--- a/lib/WebDriverPlatform.php
+++ b/lib/WebDriverPlatform.php
@@ -20,14 +20,14 @@ namespace Facebook\WebDriver;
  */
 class WebDriverPlatform
 {
-    const ANDROID = 'ANDROID';
-    const ANY = 'ANY';
-    const LINUX = 'LINUX';
-    const MAC = 'MAC';
-    const UNIX = 'UNIX';
-    const VISTA = 'VISTA';
-    const WINDOWS = 'WINDOWS';
-    const XP = 'XP';
+    const ANDROID = 'android';
+    const ANY = 'any';
+    const LINUX = 'linux';
+    const MAC = 'mac';
+    const UNIX = 'unix';
+    const VISTA = 'vista';
+    const WINDOWS = 'windows';
+    const XP = 'xp';
 
     private function __construct()
     {

--- a/tests/unit/Remote/DesiredCapabilitiesTest.php
+++ b/tests/unit/Remote/DesiredCapabilitiesTest.php
@@ -29,7 +29,7 @@ class DesiredCapabilitiesTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame('fooVal', $capabilities->getCapability('fooKey'));
-        $this->assertSame('ANY', $capabilities->getPlatform());
+        $this->assertSame('any', $capabilities->getPlatform());
 
         $this->assertSame(
             ['fooKey' => 'fooVal', WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY],


### PR DESCRIPTION
According to the [spec](https://w3c.github.io/webdriver/webdriver-spec.html#capabilities), the capability platform has changed : 

>"platformName" 
> Lowercase name of the current platform as a string. 
