### PR TITLE
Allow Symfony4 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "forum": "https://www.facebook.com/groups/phpwebdriver/",
     "source": "https://github.com/facebook/php-webdriver"
   },
+  "minimum-stability": "beta",
   "require": {
     "php": "^5.6 || ~7.0",
     "symfony/process": "^2.8 || ^3.1",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "minimum-stability": "beta",
   "require": {
     "php": "^5.6 || ~7.0",
-    "symfony/process": "^2.8 || ^3.1",
+    "symfony/process": "^2.8 || ^3.1 || ^4.0",
     "ext-curl": "*",
     "ext-zip": "*"
   },
@@ -25,7 +25,7 @@
     "php-mock/php-mock-phpunit": "^1.1",
     "php-coveralls/php-coveralls": "^1.0.2",
     "guzzle/guzzle": "^3.4.1",
-    "symfony/var-dumper": "^3.3"
+    "symfony/var-dumper": "^3.3 || ^4.0"
   },
   "autoload": {
     "psr-4": {

--- a/lib/Remote/Service/DriverService.php
+++ b/lib/Remote/Service/DriverService.php
@@ -145,11 +145,20 @@ class DriverService
      */
     private function createProcess()
     {
-        $processBuilder = (new ProcessBuilder())
-            ->setPrefix($this->executable)
-            ->setArguments($this->args)
-            ->addEnvironmentVariables($this->environment);
+        // BC: ProcessBuilder deprecated since Symfony 3.4 and removed in Symfony 4.0.
+        if (class_exists(ProcessBuilder::class)
+            && false === mb_strpos('@deprecated', (new \ReflectionClass(ProcessBuilder::class))->getDocComment())
+        ) {
+            $processBuilder = (new ProcessBuilder())
+                ->setPrefix($this->executable)
+                ->setArguments($this->args)
+                ->addEnvironmentVariables($this->environment);
 
-        return $processBuilder->getProcess();
+            return $processBuilder->getProcess();
+        }
+        // Safe to use since Symfony 3.3
+        $commandLine = array_merge([$this->executable], $this->args);
+
+        return new Process($commandLine, null, $this->environment);
     }
 }

--- a/lib/Remote/Service/DriverService.php
+++ b/lib/Remote/Service/DriverService.php
@@ -81,12 +81,7 @@ class DriverService
             return $this;
         }
 
-        $processBuilder = (new ProcessBuilder())
-            ->setPrefix($this->executable)
-            ->setArguments($this->args)
-            ->addEnvironmentVariables($this->environment);
-
-        $this->process = $processBuilder->getProcess();
+        $this->process = $this->createProcess();
         $this->process->start();
 
         $checker = new URLChecker();
@@ -143,5 +138,18 @@ class DriverService
         }
 
         return $executable;
+    }
+
+    /**
+     * @return Process
+     */
+    private function createProcess()
+    {
+        $processBuilder = (new ProcessBuilder())
+            ->setPrefix($this->executable)
+            ->setArguments($this->args)
+            ->addEnvironmentVariables($this->environment);
+
+        return $processBuilder->getProcess();
     }
 }


### PR DESCRIPTION
Symfony4 is in beta now and I think that it's time to allow developers test theirs projects with new set of components. But php-webdriver blocks install some of its. This PR allow.