### PR TITLE
Adding WebDriverExpectedCondition::visibilityOfAnyElementsLocated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Drop PHP 5.5 support, the minimal required version of PHP is now PHP 5.6.
 
+### Added
+- Added a visibilityOfAnyElementsLocated method to WebDriverExpectedCondition.
+
 ## 1.4.1 - 2017-04-28
 ### Fixed
 - Do not throw notice `Constant CURLOPT_CONNECTTIMEOUT_MS already defined`.

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -194,6 +194,35 @@ class WebDriverExpectedCondition
     }
 
     /**
+     * An expectation for checking than at least one element in an array of elements is present on the
+     * DOM of a page and visible.
+     * Visibility means that the element is not only displayed but also has a height and width that is greater than 0.
+     *
+     * @param WebDriverBy $by The located used to find the element.
+     * @return WebDriverExpectedCondition<WebDriverElement> Condition returns the elements that are located and visible.
+     */
+    public static function visibilityOfAnyElementLocated(WebDriverBy $by)
+    {
+        return new static(
+            function (WebDriver $driver) use ($by) {
+                $elements = $driver->findElements($by);
+                $visibleElements = [];
+
+                foreach ($elements as $element) {
+                    try {
+                        if ($element->isDisplayed()) {
+                            $visibleElements[] = $element;
+                        }
+                    } catch (StateElementReferenceException $e) {
+                    }
+                }
+
+                return count($visibleElements) > 0 ? $visibleElements : null;
+            }
+        );
+    }
+
+    /**
      * An expectation for checking that an element, known to be present on the DOM of a page, is visible.
      * Visibility means that the element is not only displayed but also has a height and width that is greater than 0.
      *

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -185,6 +185,36 @@ class WebDriverExpectedConditionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($element, $this->wait->until($condition));
     }
 
+    public function testShouldDetectVisibilityOfAnyElementLocated()
+    {
+        $elementList = [
+            $this->createRemoteWebElementMock(),
+            $this->createRemoteWebElementMock(),
+            $this->createRemoteWebElementMock(),
+        ];
+
+        $elementList[0]->expects($this->once())
+            ->method('isDisplayed')
+            ->willReturn(false);
+
+        $elementList[1]->expects($this->once())
+            ->method('isDisplayed')
+            ->willReturn(true);
+
+        $elementList[2]->expects($this->once())
+            ->method('isDisplayed')
+            ->willReturn(true);
+
+        $this->driverMock->expects($this->once())
+            ->method('findElements')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willReturn($elementList);
+
+        $condition = WebDriverExpectedCondition::visibilityOfAnyElementLocated(WebDriverBy::cssSelector('.foo'));
+
+        $this->assertSame([$elementList[1], $elementList[2]], $this->wait->until($condition));
+    }
+
     public function testShouldDetectInvisibilityOfElementLocatedConditionOnNoSuchElementException()
     {
         $element = $this->createRemoteWebElementMock();


### PR DESCRIPTION
This pull request adds a new visibilityOfAnyElementsLocated method to WebDriverExpectedCondition. This condition checks to see if any elements in an array of located elements are visible, not just the first one. This condition also returns an array of all elements that meet the criteria and are located and visible.