### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "ext-zip": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.4",
+    "phpunit/phpunit": "^5.7",
     "sebastian/environment": "^1.3.4 || ^2.0 || ^3.0",
     "friendsofphp/php-cs-fixer": "^2.0",
     "squizlabs/php_codesniffer": "^2.6",

--- a/tests/functional/Chrome/ChromeDriverServiceTest.php
+++ b/tests/functional/Chrome/ChromeDriverServiceTest.php
@@ -15,12 +15,14 @@
 
 namespace Facebook\WebDriver\Chrome;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group exclude-saucelabs
  * @covers Facebook\WebDriver\Chrome\ChromeDriverService
  * @covers Facebook\WebDriver\Remote\Service\DriverService
  */
-class ChromeDriverServiceTest extends \PHPUnit_Framework_TestCase
+class ChromeDriverServiceTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/functional/Chrome/ChromeDriverTest.php
+++ b/tests/functional/Chrome/ChromeDriverTest.php
@@ -17,12 +17,13 @@ namespace Facebook\WebDriver\Chrome;
 
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\Service\DriverCommandExecutor;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group exclude-saucelabs
  * @covers Facebook\WebDriver\Chrome\ChromeDriver
  */
-class ChromeDriverTest extends \PHPUnit_Framework_TestCase
+class ChromeDriverTest extends TestCase
 {
     /** @var ChromeDriver */
     protected $driver;

--- a/tests/functional/ReportSauceLabsStatusListener.php
+++ b/tests/functional/ReportSauceLabsStatusListener.php
@@ -16,8 +16,9 @@
 namespace Facebook\WebDriver;
 
 use Facebook\WebDriver\Remote\RemoteWebDriver;
+use PHPUnit\Framework\BaseTestListener;
 
-class ReportSauceLabsStatusListener extends \PHPUnit_Framework_BaseTestListener
+class ReportSauceLabsStatusListener extends BaseTestListener
 {
     public function endTest(\PHPUnit_Framework_Test $test, $time)
     {

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -20,11 +20,12 @@ use Facebook\WebDriver\Exception\NoSuchWindowException;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\WebDriverBrowserType;
+use PHPUnit\Framework\TestCase;
 
 /**
  * The base class for test cases.
  */
-class WebDriverTestCase extends \PHPUnit_Framework_TestCase
+class WebDriverTestCase extends TestCase
 {
     /** @var RemoteWebDriver $driver */
     public $driver;

--- a/tests/unit/CookieTest.php
+++ b/tests/unit/CookieTest.php
@@ -15,10 +15,12 @@
 
 namespace Facebook\WebDriver;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Facebook\WebDriver\Cookie
  */
-class CookieTest extends \PHPUnit_Framework_TestCase
+class CookieTest extends TestCase
 {
     public function testShouldSetAllProperties()
     {

--- a/tests/unit/CookieTest.php
+++ b/tests/unit/CookieTest.php
@@ -145,7 +145,7 @@ class CookieTest extends TestCase
      * @param string $domain
      * @param string $expectedMessage
      */
-    public function testShouldValidateCookie($name, $value, $domain, $expectedMessage)
+    public function testShouldValidateCookieOnConstruction($name, $value, $domain, $expectedMessage)
     {
         if ($expectedMessage) {
             $this->expectException(\InvalidArgumentException::class);
@@ -156,6 +156,8 @@ class CookieTest extends TestCase
         if ($domain !== null) {
             $cookie->setDomain($domain);
         }
+
+        $this->assertInstanceOf(Cookie::class, $cookie);
     }
 
     /**

--- a/tests/unit/Exception/WebDriverExceptionTest.php
+++ b/tests/unit/Exception/WebDriverExceptionTest.php
@@ -15,7 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
-class WebDriverExceptionTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class WebDriverExceptionTest extends TestCase
 {
     public function testShouldStoreResultsOnInstantiation()
     {

--- a/tests/unit/Interactions/Internal/WebDriverButtonReleaseActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverButtonReleaseActionTest.php
@@ -17,8 +17,9 @@ namespace Facebook\WebDriver\Interactions\Internal;
 
 use Facebook\WebDriver\Internal\WebDriverLocatable;
 use Facebook\WebDriver\WebDriverMouse;
+use PHPUnit\Framework\TestCase;
 
-class WebDriverButtonReleaseActionTest extends \PHPUnit_Framework_TestCase
+class WebDriverButtonReleaseActionTest extends TestCase
 {
     /** @var WebDriverButtonReleaseAction */
     private $webDriverButtonReleaseAction;

--- a/tests/unit/Interactions/Internal/WebDriverClickActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverClickActionTest.php
@@ -17,8 +17,9 @@ namespace Facebook\WebDriver\Interactions\Internal;
 
 use Facebook\WebDriver\Internal\WebDriverLocatable;
 use Facebook\WebDriver\WebDriverMouse;
+use PHPUnit\Framework\TestCase;
 
-class WebDriverClickActionTest extends \PHPUnit_Framework_TestCase
+class WebDriverClickActionTest extends TestCase
 {
     /** @var WebDriverClickAction */
     private $webDriverClickAction;

--- a/tests/unit/Interactions/Internal/WebDriverClickAndHoldActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverClickAndHoldActionTest.php
@@ -17,8 +17,9 @@ namespace Facebook\WebDriver\Interactions\Internal;
 
 use Facebook\WebDriver\Internal\WebDriverLocatable;
 use Facebook\WebDriver\WebDriverMouse;
+use PHPUnit\Framework\TestCase;
 
-class WebDriverClickAndHoldActionTest extends \PHPUnit_Framework_TestCase
+class WebDriverClickAndHoldActionTest extends TestCase
 {
     /** @var WebDriverClickAndHoldAction */
     private $webDriverClickAndHoldAction;

--- a/tests/unit/Interactions/Internal/WebDriverContextClickActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverContextClickActionTest.php
@@ -17,8 +17,9 @@ namespace Facebook\WebDriver\Interactions\Internal;
 
 use Facebook\WebDriver\Internal\WebDriverLocatable;
 use Facebook\WebDriver\WebDriverMouse;
+use PHPUnit\Framework\TestCase;
 
-class WebDriverContextClickActionTest extends \PHPUnit_Framework_TestCase
+class WebDriverContextClickActionTest extends TestCase
 {
     /** @var WebDriverContextClickAction */
     private $webDriverContextClickAction;

--- a/tests/unit/Interactions/Internal/WebDriverCoordinatesTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverCoordinatesTest.php
@@ -15,7 +15,9 @@
 
 namespace Facebook\WebDriver\Interactions\Internal;
 
-class WebDriverCoordinatesTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class WebDriverCoordinatesTest extends TestCase
 {
     public function testConstruct()
     {

--- a/tests/unit/Interactions/Internal/WebDriverDoubleClickActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverDoubleClickActionTest.php
@@ -17,8 +17,9 @@ namespace Facebook\WebDriver\Interactions\Internal;
 
 use Facebook\WebDriver\Internal\WebDriverLocatable;
 use Facebook\WebDriver\WebDriverMouse;
+use PHPUnit\Framework\TestCase;
 
-class WebDriverDoubleClickActionTest extends \PHPUnit_Framework_TestCase
+class WebDriverDoubleClickActionTest extends TestCase
 {
     /** @var WebDriverDoubleClickAction */
     private $webDriverDoubleClickAction;

--- a/tests/unit/Interactions/Internal/WebDriverKeyDownActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverKeyDownActionTest.php
@@ -18,8 +18,9 @@ namespace Facebook\WebDriver\Interactions\Internal;
 use Facebook\WebDriver\Internal\WebDriverLocatable;
 use Facebook\WebDriver\WebDriverKeyboard;
 use Facebook\WebDriver\WebDriverMouse;
+use PHPUnit\Framework\TestCase;
 
-class WebDriverKeyDownActionTest extends \PHPUnit_Framework_TestCase
+class WebDriverKeyDownActionTest extends TestCase
 {
     /** @var WebDriverKeyDownAction */
     private $webDriverKeyDownAction;

--- a/tests/unit/Interactions/Internal/WebDriverKeyUpActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverKeyUpActionTest.php
@@ -18,8 +18,9 @@ namespace Facebook\WebDriver\Interactions\Internal;
 use Facebook\WebDriver\Internal\WebDriverLocatable;
 use Facebook\WebDriver\WebDriverKeyboard;
 use Facebook\WebDriver\WebDriverMouse;
+use PHPUnit\Framework\TestCase;
 
-class WebDriverKeyUpActionTest extends \PHPUnit_Framework_TestCase
+class WebDriverKeyUpActionTest extends TestCase
 {
     /** @var WebDriverKeyUpAction */
     private $webDriverKeyUpAction;

--- a/tests/unit/Interactions/Internal/WebDriverMouseMoveActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverMouseMoveActionTest.php
@@ -17,8 +17,9 @@ namespace Facebook\WebDriver\Interactions\Internal;
 
 use Facebook\WebDriver\Internal\WebDriverLocatable;
 use Facebook\WebDriver\WebDriverMouse;
+use PHPUnit\Framework\TestCase;
 
-class WebDriverMouseMoveActionTest extends \PHPUnit_Framework_TestCase
+class WebDriverMouseMoveActionTest extends TestCase
 {
     /** @var WebDriverMouseMoveAction */
     private $webDriverMouseMoveAction;

--- a/tests/unit/Interactions/Internal/WebDriverMouseToOffsetActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverMouseToOffsetActionTest.php
@@ -17,8 +17,9 @@ namespace Facebook\WebDriver\Interactions\Internal;
 
 use Facebook\WebDriver\Internal\WebDriverLocatable;
 use Facebook\WebDriver\WebDriverMouse;
+use PHPUnit\Framework\TestCase;
 
-class WebDriverMouseToOffsetActionTest extends \PHPUnit_Framework_TestCase
+class WebDriverMouseToOffsetActionTest extends TestCase
 {
     /**
      * @type WebDriverMoveToOffsetAction

--- a/tests/unit/Interactions/Internal/WebDriverSendKeysActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverSendKeysActionTest.php
@@ -18,8 +18,9 @@ namespace Facebook\WebDriver\Interactions\Internal;
 use Facebook\WebDriver\Internal\WebDriverLocatable;
 use Facebook\WebDriver\WebDriverKeyboard;
 use Facebook\WebDriver\WebDriverMouse;
+use PHPUnit\Framework\TestCase;
 
-class WebDriverSendKeysActionTest extends \PHPUnit_Framework_TestCase
+class WebDriverSendKeysActionTest extends TestCase
 {
     /** @var WebDriverSendKeysAction */
     private $webDriverSendKeysAction;

--- a/tests/unit/Remote/DesiredCapabilitiesTest.php
+++ b/tests/unit/Remote/DesiredCapabilitiesTest.php
@@ -19,8 +19,9 @@ use Facebook\WebDriver\Firefox\FirefoxDriver;
 use Facebook\WebDriver\Firefox\FirefoxPreferences;
 use Facebook\WebDriver\Firefox\FirefoxProfile;
 use Facebook\WebDriver\WebDriverPlatform;
+use PHPUnit\Framework\TestCase;
 
-class DesiredCapabilitiesTest extends \PHPUnit_Framework_TestCase
+class DesiredCapabilitiesTest extends TestCase
 {
     public function testShouldInstantiateWithCapabilitiesGivenInConstructor()
     {

--- a/tests/unit/Remote/HttpCommandExecutorTest.php
+++ b/tests/unit/Remote/HttpCommandExecutorTest.php
@@ -16,8 +16,9 @@
 namespace Facebook\WebDriver\Remote;
 
 use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\TestCase;
 
-class HttpCommandExecutorTest extends \PHPUnit_Framework_TestCase
+class HttpCommandExecutorTest extends TestCase
 {
     use PHPMock;
 

--- a/tests/unit/Remote/RemoteWebDriverTest.php
+++ b/tests/unit/Remote/RemoteWebDriverTest.php
@@ -19,13 +19,14 @@ use Facebook\WebDriver\Interactions\WebDriverActions;
 use Facebook\WebDriver\WebDriverNavigation;
 use Facebook\WebDriver\WebDriverOptions;
 use Facebook\WebDriver\WebDriverWait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit part of RemoteWebDriver tests. Ie. tests for behavior which do not interact with the real remote server.
  *
  * @coversDefaultClass Facebook\WebDriver\Remote\RemoteWebDriver
  */
-class RemoteWebDriverTest extends \PHPUnit_Framework_TestCase
+class RemoteWebDriverTest extends TestCase
 {
     /** @var RemoteWebDriver */
     private $driver;

--- a/tests/unit/Remote/RemoteWebElementTest.php
+++ b/tests/unit/Remote/RemoteWebElementTest.php
@@ -15,12 +15,14 @@
 
 namespace Facebook\WebDriver\Remote;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Unit part of RemoteWebDriver tests. Ie. tests for behavior which do not interact with the real remote server.
  *
  * @coversDefaultClass Facebook\WebDriver\Remote\RemoteWebElement
  */
-class RemoteWebElementTest extends \PHPUnit_Framework_TestCase
+class RemoteWebElementTest extends TestCase
 {
     /**
      * @covers ::__construct

--- a/tests/unit/Remote/WebDriverCommandTest.php
+++ b/tests/unit/Remote/WebDriverCommandTest.php
@@ -15,7 +15,9 @@
 
 namespace Facebook\WebDriver\Remote;
 
-class WebDriverCommandTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class WebDriverCommandTest extends TestCase
 {
     public function testShouldSetOptionsUsingConstructor()
     {

--- a/tests/unit/Support/XPathEscaperTest.php
+++ b/tests/unit/Support/XPathEscaperTest.php
@@ -15,7 +15,9 @@
 
 namespace Facebook\WebDriver\Support;
 
-class XPathEscaperTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class XPathEscaperTest extends TestCase
 {
     /**
      * @dataProvider xpathProvider

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -20,11 +20,12 @@ use Facebook\WebDriver\Exception\StaleElementReferenceException;
 use Facebook\WebDriver\Remote\RemoteExecuteMethod;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\RemoteWebElement;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Facebook\WebDriver\WebDriverExpectedCondition
  */
-class WebDriverExpectedConditionTest extends \PHPUnit_Framework_TestCase
+class WebDriverExpectedConditionTest extends TestCase
 {
     /** @var RemoteWebDriver|\PHPUnit_Framework_MockObject_MockObject */
     private $driverMock;

--- a/tests/unit/WebDriverKeysTest.php
+++ b/tests/unit/WebDriverKeysTest.php
@@ -15,10 +15,12 @@
 
 namespace Facebook\WebDriver;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Facebook\WebDriver\WebDriverKeys
  */
-class WebDriverKeysTest extends \PHPUnit_Framework_TestCase
+class WebDriverKeysTest extends TestCase
 {
     /**
      * @dataProvider provideKeys

--- a/tests/unit/WebDriverOptionsTest.php
+++ b/tests/unit/WebDriverOptionsTest.php
@@ -17,11 +17,12 @@ namespace Facebook\WebDriver;
 
 use Facebook\WebDriver\Remote\DriverCommand;
 use Facebook\WebDriver\Remote\ExecuteMethod;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Facebook\WebDriver\WebDriverOptions
  */
-class WebDriverOptionsTest extends \PHPUnit_Framework_TestCase
+class WebDriverOptionsTest extends TestCase
 {
     /** @var ExecuteMethod|\PHPUnit_Framework_MockObject_MockObject */
     private $executor;


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).