### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,9 @@ We love to have your help to make php-webdriver better!
 Feel free to open an [issue](https://github.com/facebook/php-webdriver/issues) if you run into any problem, or
 send a pull request (see bellow) with your contribution.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Workflow when contributing a patch
 
 1. Fork the project on GitHub


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the php-webdriver community profile](https://github.com/facebook/php-webdriver/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1295" alt="screen shot 2017-11-26 at 4 27 41 pm" src="https://user-images.githubusercontent.com/1114467/33246222-db7513d2-d2c6-11e7-8871-f26681148214.png">
<img width="1300" alt="screen shot 2017-11-26 at 4 27 49 pm" src="https://user-images.githubusercontent.com/1114467/33246223-db8e9f8c-d2c6-11e7-9cc9-a1add271cb05.png">

**issue:**
internal task t23481323