### PR TITLE
Update PHPDoc for functions that return static instances of a class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 - Connection and request timeouts could be specified also when creating RemoteWebDriver from existing session ID.
+- Update PHPDoc for functions that return static instances of a class.
 
 ## 1.5.0 - 2017-11-15
 ### Changed

--- a/lib/Chrome/ChromeDriver.php
+++ b/lib/Chrome/ChromeDriver.php
@@ -24,6 +24,9 @@ use Facebook\WebDriver\Remote\WebDriverCommand;
 
 class ChromeDriver extends RemoteWebDriver
 {
+    /**
+     * @return static
+     */
     public static function start(DesiredCapabilities $desired_capabilities = null, ChromeDriverService $service = null)
     {
         if ($desired_capabilities === null) {

--- a/lib/Chrome/ChromeDriverService.php
+++ b/lib/Chrome/ChromeDriverService.php
@@ -22,6 +22,9 @@ class ChromeDriverService extends DriverService
     // The environment variable storing the path to the chrome driver executable.
     const CHROME_DRIVER_EXE_PROPERTY = 'webdriver.chrome.driver';
 
+    /**
+     * @return static
+     */
     public static function createDefaultService()
     {
         $exe = getenv(self::CHROME_DRIVER_EXE_PROPERTY);

--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -178,7 +178,7 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
-     * @return DesiredCapabilities
+     * @return static
      */
     public static function android()
     {
@@ -189,7 +189,7 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
-     * @return DesiredCapabilities
+     * @return static
      */
     public static function chrome()
     {
@@ -200,7 +200,7 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
-     * @return DesiredCapabilities
+     * @return static
      */
     public static function firefox()
     {
@@ -218,7 +218,7 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
-     * @return DesiredCapabilities
+     * @return static
      */
     public static function htmlUnit()
     {
@@ -229,7 +229,7 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
-     * @return DesiredCapabilities
+     * @return static
      */
     public static function htmlUnitWithJS()
     {
@@ -242,7 +242,7 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
-     * @return DesiredCapabilities
+     * @return static
      */
     public static function internetExplorer()
     {
@@ -253,7 +253,7 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
-     * @return DesiredCapabilities
+     * @return static
      */
     public static function microsoftEdge()
     {
@@ -264,7 +264,7 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
-     * @return DesiredCapabilities
+     * @return static
      */
     public static function iphone()
     {
@@ -275,7 +275,7 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
-     * @return DesiredCapabilities
+     * @return static
      */
     public static function ipad()
     {
@@ -286,7 +286,7 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
-     * @return DesiredCapabilities
+     * @return static
      */
     public static function opera()
     {
@@ -297,7 +297,7 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
-     * @return DesiredCapabilities
+     * @return static
      */
     public static function safari()
     {
@@ -308,7 +308,7 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
-     * @return DesiredCapabilities
+     * @return static
      */
     public static function phantomjs()
     {

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -87,7 +87,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      * @param string|null $http_proxy The proxy to tunnel requests to the remote Selenium WebDriver through
      * @param int|null $http_proxy_port The proxy port to tunnel requests to the remote Selenium WebDriver through
      * @param DesiredCapabilities $required_capabilities The required capabilities
-     * @return RemoteWebDriver
+     * @return static
      */
     public static function create(
         $selenium_server_url = 'http://localhost:4444/wd/hub',
@@ -141,7 +141,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      * @param string $session_id The existing session id
      * @param int|null $connection_timeout_in_ms Set timeout for the connect phase to remote Selenium WebDriver server
      * @param int|null $request_timeout_in_ms Set the maximum time of a request to remote Selenium WebDriver server
-     * @return RemoteWebDriver
+     * @return static
      */
     public static function createBySessionID(
         $session_id,

--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -408,7 +408,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
      *
      * @param string $id
      *
-     * @return RemoteWebElement
+     * @return static
      */
     protected function newElement($id)
     {

--- a/lib/Support/Events/EventFiringWebElement.php
+++ b/lib/Support/Events/EventFiringWebElement.php
@@ -405,7 +405,7 @@ class EventFiringWebElement implements WebDriverElement, WebDriverLocatable
 
     /**
      * @param WebDriverElement $element
-     * @return EventFiringWebElement
+     * @return static
      */
     protected function newElement(WebDriverElement $element)
     {

--- a/lib/WebDriverBy.php
+++ b/lib/WebDriverBy.php
@@ -60,7 +60,7 @@ class WebDriverBy
      * names are not permitted.
      *
      * @param string $class_name
-     * @return WebDriverBy
+     * @return static
      */
     public static function className($class_name)
     {
@@ -71,7 +71,7 @@ class WebDriverBy
      * Locates elements matching a CSS selector.
      *
      * @param string $css_selector
-     * @return WebDriverBy
+     * @return static
      */
     public static function cssSelector($css_selector)
     {
@@ -82,7 +82,7 @@ class WebDriverBy
      * Locates elements whose ID attribute matches the search value.
      *
      * @param string $id
-     * @return WebDriverBy
+     * @return static
      */
     public static function id($id)
     {
@@ -93,7 +93,7 @@ class WebDriverBy
      * Locates elements whose NAME attribute matches the search value.
      *
      * @param string $name
-     * @return WebDriverBy
+     * @return static
      */
     public static function name($name)
     {
@@ -104,7 +104,7 @@ class WebDriverBy
      * Locates anchor elements whose visible text matches the search value.
      *
      * @param string $link_text
-     * @return WebDriverBy
+     * @return static
      */
     public static function linkText($link_text)
     {
@@ -116,7 +116,7 @@ class WebDriverBy
      * value.
      *
      * @param string $partial_link_text
-     * @return WebDriverBy
+     * @return static
      */
     public static function partialLinkText($partial_link_text)
     {
@@ -127,7 +127,7 @@ class WebDriverBy
      * Locates elements whose tag name matches the search value.
      *
      * @param string $tag_name
-     * @return WebDriverBy
+     * @return static
      */
     public static function tagName($tag_name)
     {
@@ -138,7 +138,7 @@ class WebDriverBy
      * Locates elements matching an XPath expression.
      *
      * @param string $xpath
-     * @return WebDriverBy
+     * @return static
      */
     public static function xpath($xpath)
     {

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -564,7 +564,7 @@ class WebDriverExpectedCondition
      * An expectation checking the number of opened windows.
      *
      * @param int $expectedNumberOfWindows
-     * @return WebDriverExpectedCondition
+     * @return static
      */
     public static function numberOfWindowsToBe($expectedNumberOfWindows)
     {


### PR DESCRIPTION
Previously, functions that contained functionality similar to `return new static(...)` had their `@return` PHPDoc tag to specify the class name like `@return SomeClass` where the preferred documentation should be `@return static`.

Some support for this decision:
https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md#keyword
https://netbeans.org/bugzilla/show_bug.cgi?id=196565
https://blog.madewithlove.be/post/return-types/