### PR TITLE
Add .vscode folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ logs/
 *~
 *.swp
 .idea
+.vscode


### PR DESCRIPTION
Visual Studio Code users often generate a .vscode folder that contains a "workspace settings" file (settings.json) that overrides the "User settings" only for a specific project, exactly like the .idea folder does.

Like "[.idea](https://github.com/facebook/php-webdriver/blob/community/.gitignore)", this folder should be ignored by Git or any version control system.