### PR TITLE
add reply request without 100-continue expectation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Connection and request timeouts could be specified also when creating RemoteWebDriver from existing session ID.
 
+### Changed
+- Disable sending 'Expect: 100-Continue' header with POST requests, as they may more easily fail when sending via eg. squid proxy.
+
 ## 1.5.0 - 2017-11-15
 ### Changed
 - Drop PHP 5.5 support, the minimal required version of PHP is now PHP 5.6.

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -263,6 +263,12 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
             curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, $http_method);
         }
 
+        if (in_array($http_method, ['POST', 'PUT'])) {
+            // Disable sending 'Expect: 100-Continue' header, as it is causing issues with eg. squid proxy
+            // https://tools.ietf.org/html/rfc7231#section-5.1.1
+            curl_setopt($this->curl, CURLOPT_HTTPHEADER, ['Expect:']);
+        }
+
         $encoded_params = null;
 
         if ($http_method === 'POST' && $params && is_array($params)) {

--- a/tests/functional/ReportSauceLabsStatusListener.php
+++ b/tests/functional/ReportSauceLabsStatusListener.php
@@ -77,6 +77,8 @@ class ReportSauceLabsStatusListener extends BaseTestListener
         curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
         curl_setopt($curl, CURLOPT_USERPWD, getenv('SAUCE_USERNAME') . ':' . getenv('SAUCE_ACCESS_KEY'));
         curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
+        // Disable sending 'Expect: 100-Continue' header, as it is causing issues with eg. squid proxy
+        curl_setopt($curl, CURLOPT_HTTPHEADER, ['Expect:']);
 
         curl_exec($curl);
 

--- a/tests/unit/Remote/HttpCommandExecutorTest.php
+++ b/tests/unit/Remote/HttpCommandExecutorTest.php
@@ -34,19 +34,32 @@ class HttpCommandExecutorTest extends TestCase
      * @dataProvider commandProvider
      * @param int $command
      * @param array $params
+     * @param bool $shouldResetExpectHeader
      * @param string $expectedUrl
      * @param string $expectedPostData
      */
-    public function testShouldSendRequestToAssembledUrl($command, array $params, $expectedUrl, $expectedPostData)
-    {
+    public function testShouldSendRequestToAssembledUrl(
+        $command,
+        array $params,
+        $shouldResetExpectHeader,
+        $expectedUrl,
+        $expectedPostData
+    ) {
         $command = new WebDriverCommand('foo-123', $command, $params);
 
         $curlSetoptMock = $this->getFunctionMock(__NAMESPACE__, 'curl_setopt');
         $curlSetoptMock->expects($this->at(0))
             ->with($this->anything(), CURLOPT_URL, $expectedUrl);
 
-        $curlSetoptMock->expects($this->at(2))
-            ->with($this->anything(), CURLOPT_POSTFIELDS, $expectedPostData);
+        if ($shouldResetExpectHeader) {
+            $curlSetoptMock->expects($this->at(2))
+                ->with($this->anything(), CURLOPT_HTTPHEADER, ['Expect:']);
+            $curlSetoptMock->expects($this->at(3))
+                ->with($this->anything(), CURLOPT_POSTFIELDS, $expectedPostData);
+        } else {
+            $curlSetoptMock->expects($this->at(2))
+                ->with($this->anything(), CURLOPT_POSTFIELDS, $expectedPostData);
+        }
 
         $curlExecMock = $this->getFunctionMock(__NAMESPACE__, 'curl_exec');
         $curlExecMock->expects($this->once())
@@ -64,30 +77,35 @@ class HttpCommandExecutorTest extends TestCase
             'POST command having :id placeholder in url' => [
                 DriverCommand::SEND_KEYS_TO_ELEMENT,
                 ['value' => 'submitted-value', ':id' => '1337'],
+                true,
                 'http://localhost:4444/session/foo-123/element/1337/value',
                 '{"value":"submitted-value"}',
             ],
             'POST command without :id placeholder in url' => [
                 DriverCommand::TOUCH_UP,
                 ['x' => 3, 'y' => 6],
+                true,
                 'http://localhost:4444/session/foo-123/touch/up',
                 '{"x":3,"y":6}',
             ],
             'Extra useless placeholder parameter should be removed' => [
                 DriverCommand::TOUCH_UP,
                 ['x' => 3, 'y' => 6, ':useless' => 'foo'],
+                true,
                 'http://localhost:4444/session/foo-123/touch/up',
                 '{"x":3,"y":6}',
             ],
             'DELETE command' => [
                 DriverCommand::DELETE_COOKIE,
                 [':name' => 'cookie-name'],
+                false,
                 'http://localhost:4444/session/foo-123/cookie/cookie-name',
                 null,
             ],
             'GET command without session in URL' => [
                 DriverCommand::GET_ALL_SESSIONS,
                 [],
+                false,
                 'http://localhost:4444/sessions',
                 null,
             ],


### PR DESCRIPTION
This pull-request solves strict RFC HTTP/1.1 https://tools.ietf.org/html/rfc7231#section-5.1.1 behavior.

If you are communicating with a server on HTTP/1.0 old behavior is ok. But if HTTP/1.1 is used, by RFC HTTP 417 should be returned. This will probably will work on most cases, but in combination with squid proxy, you will be forced to solve it on app site.

HTTP Expect: 100-continue is added when `curl_setopt($this->curl, CURLOPT_POSTFIELDS, $encoded_params);` with not null `$encoded_params` present.