### PR TITLE
Fix not with presence condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Disable sending 'Expect: 100-Continue' header with POST requests, as they may more easily fail when sending via eg. squid proxy.
 
+### Fixed
+- Change `WebDriverExpectedCondition::presenceOfElementLocated()` to catch and convert `NoSuchElementException` to false to ensure functionality works correctly with `WebDriverExpectedCondition::not()`.
+
 ## 1.5.0 - 2017-11-15
 ### Changed
 - Drop PHP 5.5 support, the minimal required version of PHP is now PHP 5.6.

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -148,7 +148,11 @@ class WebDriverExpectedCondition
     {
         return new static(
             function (WebDriver $driver) use ($by) {
-                return $driver->findElement($by);
+                try {
+                    return $driver->findElement($by);
+                } catch (NoSuchElementException $e) {
+                    return false;
+                }
             }
         );
     }

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -135,6 +135,29 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertSame($element, $this->wait->until($condition));
     }
 
+    public function testShouldDetectAbsenceOfElementLocatedCondition()
+    {
+        $element = new RemoteWebElement(new RemoteExecuteMethod($this->driverMock), 'id');
+
+        $this->driverMock->expects($this->at(0))
+            ->method('findElement')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willReturn($element);
+
+        $this->driverMock->expects($this->at(1))
+            ->method('findElement')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willThrowException(new NoSuchElementException(''));
+
+        $condition = WebDriverExpectedCondition::not(
+            WebDriverExpectedCondition::presenceOfElementLocated(WebDriverBy::cssSelector('.foo'))
+        );
+
+        $conditionClosure = $condition->getApply();
+        $this->assertFalse($conditionClosure($this->driverMock));
+        $this->assertTrue($conditionClosure($this->driverMock));
+    }
+
     public function testShouldDetectPresenceOfAllElementsLocatedByCondition()
     {
         $element = $this->createMock(RemoteWebElement::class);


### PR DESCRIPTION
Currently doing something like the following will fail a PhpUnit test:

```
$driver->wait()->until(
    WebDriverExpectedCondition::not(
        WebDriverExpectedCondition::presenceOfElementLocated(
            WebDriverBy::cssSelector('iframe[name="modal"]')
        )
    )
);
```

This pull request is intended to fix this problem.
