### PR TITLE
Get back other http headers (Content type, Accept) in case of adding …

### DIFF
--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -26,6 +26,11 @@ use InvalidArgumentException;
  */
 class HttpCommandExecutor implements WebDriverCommandExecutor
 {
+    const DEFAULT_HTTP_HEADERS = [
+        'Content-Type: application/json;charset=UTF-8',
+        'Accept: application/json',
+    ];
+
     /**
      * @see https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#command-reference
      */
@@ -169,14 +174,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
 
         curl_setopt($this->curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($this->curl, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt(
-            $this->curl,
-            CURLOPT_HTTPHEADER,
-            [
-                'Content-Type: application/json;charset=UTF-8',
-                'Accept: application/json',
-            ]
-        );
+        curl_setopt($this->curl, CURLOPT_HTTPHEADER, static::DEFAULT_HTTP_HEADERS);
         $this->setRequestTimeout(30000);
         $this->setConnectionTimeout(30000);
     }
@@ -266,7 +264,9 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         if (in_array($http_method, ['POST', 'PUT'])) {
             // Disable sending 'Expect: 100-Continue' header, as it is causing issues with eg. squid proxy
             // https://tools.ietf.org/html/rfc7231#section-5.1.1
-            curl_setopt($this->curl, CURLOPT_HTTPHEADER, ['Expect:']);
+            curl_setopt($this->curl, CURLOPT_HTTPHEADER, array_merge(static::DEFAULT_HTTP_HEADERS, ['Expect:']));
+        } else {
+            curl_setopt($this->curl, CURLOPT_HTTPHEADER, static::DEFAULT_HTTP_HEADERS);
         }
 
         $encoded_params = null;

--- a/tests/unit/Remote/HttpCommandExecutorTest.php
+++ b/tests/unit/Remote/HttpCommandExecutorTest.php
@@ -53,11 +53,21 @@ class HttpCommandExecutorTest extends TestCase
 
         if ($shouldResetExpectHeader) {
             $curlSetoptMock->expects($this->at(2))
-                ->with($this->anything(), CURLOPT_HTTPHEADER, ['Expect:']);
+                ->with(
+                    $this->anything(),
+                    CURLOPT_HTTPHEADER,
+                    ['Content-Type: application/json;charset=UTF-8', 'Accept: application/json', 'Expect:']
+                );
             $curlSetoptMock->expects($this->at(3))
                 ->with($this->anything(), CURLOPT_POSTFIELDS, $expectedPostData);
         } else {
             $curlSetoptMock->expects($this->at(2))
+                ->with(
+                    $this->anything(),
+                    CURLOPT_HTTPHEADER,
+                    ['Content-Type: application/json;charset=UTF-8', 'Accept: application/json']
+                );
+            $curlSetoptMock->expects($this->at(3))
                 ->with($this->anything(), CURLOPT_POSTFIELDS, $expectedPostData);
         }
 


### PR DESCRIPTION
A colleague has found that this pull request brokes communication with Appium. Appium response gives `Invalid parameter response`, in the case when Except header is set. 

After some investigation, I have found that my code
`curl_setopt($this->curl, CURLOPT_HTTPHEADER, ['Expect:'];`

do not add the header, but re-sets all HTTP headers. So it removes those from constructor part:
`[
                'Content-Type: application/json;charset=UTF-8',
                'Accept: application/json'
]`
