### PR TITLE
Allow combined not() and presenceOfElementLocated() functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 - Revert no longer needed workaround for Chromedriver bug [2943](https://bugs.chromium.org/p/chromedriver/issues/detail?id=2943).
 - Allow installation of Symfony 5 components.
 
+### Fixed
+- `WebDriverExpectedCondition::presenceOfElementLocated()` works correctly when used within `WebDriverExpectedCondition::not()`.
+
 ## 1.7.1 - 2019-06-13
 ### Fixed
 - Error `Call to a member function toArray()` if capabilities were already converted to an array.

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -148,7 +148,11 @@ class WebDriverExpectedCondition
     {
         return new static(
             function (WebDriver $driver) use ($by) {
-                return $driver->findElement($by);
+                try {
+                    return $driver->findElement($by);
+                } catch (NoSuchElementException $e) {
+                    return false;
+                }
             }
         );
     }
@@ -423,8 +427,7 @@ class WebDriverExpectedCondition
      */
     public static function elementToBeClickable(WebDriverBy $by)
     {
-        $visibility_of_element_located =
-            self::visibilityOfElementLocated($by);
+        $visibility_of_element_located = self::visibilityOfElementLocated($by);
 
         return new static(
             function (WebDriver $driver) use ($visibility_of_element_located) {

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -135,6 +135,28 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertSame($element, $this->wait->until($condition));
     }
 
+    public function testShouldDetectNotPresenceOfElementLocatedCondition()
+    {
+        $element = new RemoteWebElement(new RemoteExecuteMethod($this->driverMock), 'id');
+
+        $this->driverMock->expects($this->at(0))
+            ->method('findElement')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willReturn($element);
+
+        $this->driverMock->expects($this->at(1))
+            ->method('findElement')
+            ->with($this->isInstanceOf(WebDriverBy::class))
+            ->willThrowException(new NoSuchElementException(''));
+
+        $condition = WebDriverExpectedCondition::not(
+            WebDriverExpectedCondition::presenceOfElementLocated(WebDriverBy::cssSelector('.foo'))
+        );
+
+        $this->assertFalse(call_user_func($condition->getApply(), $this->driverMock));
+        $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
+    }
+
     public function testShouldDetectPresenceOfAllElementsLocatedByCondition()
     {
         $element = $this->createMock(RemoteWebElement::class);
@@ -160,7 +182,7 @@ class WebDriverExpectedConditionTest extends TestCase
         // Call #1: throws NoSuchElementException
         // Call #2: return Element, but isDisplayed will throw StaleElementReferenceException
         // Call #3: return Element, but isDisplayed will return false
-        // Call #4: return Element, isDisplayed will true and condition will match
+        // Call #4: return Element, isDisplayed will return true and condition will match
 
         $element = $this->createMock(RemoteWebElement::class);
         $element->expects($this->at(0))


### PR DESCRIPTION
Currently doing something like the following will cause a PhpUnit test to fail due to an exception thrown by the `presenceOfElementLocated()` call when the element is not present:

```
$driver->wait()->until(
    WebDriverExpectedCondition::not(
        WebDriverExpectedCondition::presenceOfElementLocated(
            WebDriverBy::cssSelector('iframe[name="modal"]')
        )
    )
);
```

This pull request is intended to fix this problem.

Rebased against latest master as previous pull request appears to have failed travis build due to saucelabs timeout.