### PR TITLE
W3C-compliant implementation, native geckodriver support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,20 @@ matrix:
       env: DEPENDENCIES="--prefer-lowest"
 
     # Firefox inside Travis environment
-    - php: '7.3'
+    - name: 'Firefox 45 on Travis (OSS protocol)'
+      php: '7.3'
       env: BROWSER_NAME="firefox"
       addons:
         firefox: "45.8.0esr"
+
+    # Firefox with Geckodriver (W3C mode) inside Travis environment
+    - name: 'Firefox latest on Travis (W3C protocol)'
+      php: 7.3
+      env:
+        - BROWSER_NAME="firefox"
+        - GECKODRIVER="1"
+      addons:
+        firefox: latest
 
     # Stable Chrome + Chromedriver inside Travis environment
     - php: '7.3'

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ install:
 before_script:
   - if [ "$BROWSER_NAME" = "chrome" ]; then mkdir chromedriver; CHROMEDRIVER_VERSION=$(wget -qO- "https://chromedriver.storage.googleapis.com/LATEST_RELEASE"); wget -q -t 3 https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip; unzip chromedriver_linux64 -d chromedriver; fi
   - if [ "$BROWSER_NAME" = "chrome" ]; then export CHROMEDRIVER_PATH=$PWD/chromedriver/chromedriver; fi
-  - if [ "$GECKODRIVER" = "1" ]; then mkdir geckodriver; wget -q -t 3 https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz; tar xzf geckodriver-v0.24.0-linux64.tar.gz -C geckodriver; fi
+  - if [ "$GECKODRIVER" = "1" ]; then mkdir geckodriver; wget -q -t 3 https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz; tar xzf geckodriver-v0.26.0-linux64.tar.gz -C geckodriver; fi
   - sh -e /etc/init.d/xvfb start
   - if [ ! -f jar/selenium-server-standalone-3.8.1.jar ]; then wget -q -t 3 -P jar https://selenium-release.storage.googleapis.com/3.8/selenium-server-standalone-3.8.1.jar; fi
   - if [ "$GECKODRIVER" = "1" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,9 +108,14 @@ install:
 before_script:
   - if [ "$BROWSER_NAME" = "chrome" ]; then mkdir chromedriver; CHROMEDRIVER_VERSION=$(wget -qO- "https://chromedriver.storage.googleapis.com/LATEST_RELEASE"); wget -q -t 3 https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip; unzip chromedriver_linux64 -d chromedriver; fi
   - if [ "$BROWSER_NAME" = "chrome" ]; then export CHROMEDRIVER_PATH=$PWD/chromedriver/chromedriver; fi
+  - if [ "$GECKODRIVER" = "1" ]; then mkdir geckodriver; wget -q -t 3 https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz; tar xzf geckodriver-v0.24.0-linux64.tar.gz -C geckodriver; fi
   - sh -e /etc/init.d/xvfb start
   - if [ ! -f jar/selenium-server-standalone-3.8.1.jar ]; then wget -q -t 3 -P jar https://selenium-release.storage.googleapis.com/3.8/selenium-server-standalone-3.8.1.jar; fi
-  - java -Dwebdriver.firefox.marionette=false -Dwebdriver.chrome.driver="$CHROMEDRIVER_PATH" -jar jar/selenium-server-standalone-3.8.1.jar -enablePassThrough false -log ./logs/selenium.log &
+  - if [ "$GECKODRIVER" = "1" ]; then
+      geckodriver/geckodriver &> ./logs/geckodriver.log &
+    else
+      java -Dwebdriver.firefox.marionette=false -Dwebdriver.chrome.driver="$CHROMEDRIVER_PATH" -jar jar/selenium-server-standalone-3.8.1.jar -enablePassThrough false -log ./logs/selenium.log &
+    fi
   - until $(echo | nc localhost 4444); do sleep 1; echo Waiting for Selenium server on port 4444...; done; echo "Selenium server started"
   - php -S 127.0.0.1:8000 -t tests/functional/web/ &>>./logs/php-server.log &
   - until $(echo | nc localhost 8000); do sleep 1; echo waiting for PHP server on port 8000...; done; echo "PHP server started"
@@ -124,6 +129,7 @@ script:
 after_script:
   - if [ -f ./logs/selenium.log ]; then cat ./logs/selenium.log; fi
   - if [ -f ./logs/php-server.log ]; then cat ./logs/php-server.log; fi
+  - if [ -f ./logs/geckodriver.log ]; then cat ./logs/geckodriver.log; fi
 
 after_success:
   - travis_retry php vendor/bin/php-coveralls -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,15 +37,21 @@ For the functional tests you must first [download](http://selenium-release.stora
 the selenium standalone server, start the local PHP server which will serve the test pages and then run the `functional`
 test suite:
 
-    java -jar selenium-server-standalone-2.53.1.jar -log selenium.log &
+    java -jar selenium-server-standalone-3.9.1.jar -log selenium.log &
     php -S localhost:8000 -t tests/functional/web/ &
     ./vendor/bin/phpunit --testsuite functional
-    
+
 The functional tests will be started in HtmlUnit headless browser by default. If you want to run them in eg. Firefox,
 simply set the `BROWSER_NAME` environment variable:
 
     ...
     export BROWSER_NAME="firefox"
+    ./vendor/bin/phpunit --testsuite functional
+
+To test with Geckodriver, [download](https://github.com/mozilla/geckodriver/releases) and start the server, then run:
+
+    export GECKODRIVER=1
+    export BROWSER_NAME=firefox
     ./vendor/bin/phpunit --testsuite functional
 
 ### Check coding style

--- a/lib/AbstractWebDriverCheckboxOrRadio.php
+++ b/lib/AbstractWebDriverCheckboxOrRadio.php
@@ -211,7 +211,7 @@ abstract class AbstractWebDriverCheckboxOrRadio implements WebDriverSelectInterf
             $form = $this->element->findElement(WebDriverBy::xpath('ancestor::form'));
 
             $formId = $form->getAttribute('id');
-            if ($formId === '') {
+            if (!$formId) {
                 return $form->findElements(WebDriverBy::xpath(
                     sprintf('.//input[@name = %s%s]', XPathEscaper::escapeQuotes($this->name), $valueSelector)
                 ));

--- a/lib/Cookie.php
+++ b/lib/Cookie.php
@@ -190,7 +190,13 @@ class Cookie implements \ArrayAccess
      */
     public function toArray()
     {
-        return $this->cookie;
+        $cookie = $this->cookie;
+        if (!isset($cookie['secure'])) {
+            // Passing a boolean value for the "secure" flag is mandatory when using geckodriver
+            $cookie['secure'] = false;
+        }
+
+        return $cookie;
     }
 
     public function offsetExists($offset)

--- a/lib/Exception/WebDriverException.php
+++ b/lib/Exception/WebDriverException.php
@@ -42,7 +42,7 @@ class WebDriverException extends Exception
     /**
      * Throw WebDriverExceptions based on WebDriver status code.
      *
-     * @param int $status_code
+     * @param int|string $status_code
      * @param string $message
      * @param mixed $results
      *
@@ -85,6 +85,54 @@ class WebDriverException extends Exception
      */
     public static function throwException($status_code, $message, $results)
     {
+        if (is_string($status_code)) {
+            // see https://w3c.github.io/webdriver/webdriver-spec.html#handling-errors
+            switch ($status_code) {
+                case 'no such element':
+                    throw new NoSuchElementException($message, $results);
+                case 'no such frame':
+                    throw new NoSuchFrameException($message, $results);
+                case 'unknown command':
+                    throw new UnknownCommandException($message, $results);
+                case 'stale element reference':
+                    throw new StaleElementReferenceException($message, $results);
+                case 'invalid element state':
+                    throw new InvalidElementStateException($message, $results);
+                case 'unknown error':
+                    throw new UnknownServerException($message, $results);
+                case 'unsupported operation':
+                    throw new ExpectedException($message, $results);
+                case 'element not interactable':
+                    throw new ElementNotSelectableException($message, $results);
+                case 'no such window':
+                    throw new NoSuchDocumentException($message, $results);
+                case 'javascript error':
+                    throw new UnexpectedJavascriptException($message, $results);
+                case 'timeout':
+                    throw new TimeOutException($message, $results);
+                case 'no such window':
+                    throw new NoSuchWindowException($message, $results);
+                case 'invalid cookie domain':
+                    throw new InvalidCookieDomainException($message, $results);
+                case 'unable to set cookie':
+                    throw new UnableToSetCookieException($message, $results);
+                case 'unexpected alert open':
+                    throw new UnexpectedAlertOpenException($message, $results);
+                case 'no such alert':
+                    throw new NoAlertOpenException($message, $results);
+                case 'script timeout':
+                    throw new ScriptTimeoutException($message, $results);
+                case 'invalid selector':
+                    throw new InvalidSelectorException($message, $results);
+                case 'session not created':
+                    throw new SessionNotCreatedException($message, $results);
+                case 'move target out of bounds':
+                    throw new MoveTargetOutOfBoundsException($message, $results);
+                default:
+                    throw new UnrecognizedExceptionException($message, $results);
+            }
+        }
+
         switch ($status_code) {
             case 1:
                 throw new IndexOutOfBoundsException($message, $results);

--- a/lib/Interactions/WebDriverActions.php
+++ b/lib/Interactions/WebDriverActions.php
@@ -25,7 +25,6 @@ use Facebook\WebDriver\Interactions\Internal\WebDriverKeyUpAction;
 use Facebook\WebDriver\Interactions\Internal\WebDriverMouseMoveAction;
 use Facebook\WebDriver\Interactions\Internal\WebDriverMoveToOffsetAction;
 use Facebook\WebDriver\Interactions\Internal\WebDriverSendKeysAction;
-use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverElement;
 use Facebook\WebDriver\WebDriverHasInputDevices;
 

--- a/lib/Remote/DriverCommand.php
+++ b/lib/Remote/DriverCommand.php
@@ -146,6 +146,10 @@ class DriverCommand
     const GET_NETWORK_CONNECTION = 'getNetworkConnection';
     const SET_NETWORK_CONNECTION = 'setNetworkConnection';
 
+    // W3C specific
+    const ACTIONS = 'actions';
+    const GET_ELEMENT_PROPERTY = 'getElementProperty';
+
     private function __construct()
     {
     }

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -313,8 +313,13 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
 
         $encoded_params = null;
 
-        if ($http_method === 'POST' && $params && is_array($params)) {
-            $encoded_params = json_encode($params);
+        if ($http_method === 'POST') {
+            if ($params && is_array($params)) {
+                $encoded_params = json_encode($params);
+            } elseif ($this->w3cCompliant) {
+                // POST body must be valid JSON in W3C, even if empty: https://www.w3.org/TR/webdriver/#processing-model
+                $encoded_params = '{}';
+            }
         }
 
         curl_setopt($this->curl, CURLOPT_POSTFIELDS, $encoded_params);

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -138,6 +138,29 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         DriverCommand::TOUCH_UP => ['method' => 'POST', 'url' => '/session/:sessionId/touch/up'],
     ];
     /**
+     * @var array Will be merged with $commands
+     */
+    protected static $w3cCompliantCommands = [
+        DriverCommand::ACCEPT_ALERT => ['method' => 'POST', 'url' => '/session/:sessionId/alert/accept'],
+        DriverCommand::ACTIONS => ['method' => 'POST', 'url' => '/session/:sessionId/actions'],
+        DriverCommand::DISMISS_ALERT => ['method' => 'POST', 'url' => '/session/:sessionId/alert/dismiss'],
+        DriverCommand::EXECUTE_SCRIPT => ['method' => 'POST', 'url' => '/session/:sessionId/execute/sync'],
+        DriverCommand::EXECUTE_ASYNC_SCRIPT => ['method' => 'POST', 'url' => '/session/:sessionId/execute/async'],
+        DriverCommand::GET_CURRENT_WINDOW_HANDLE => ['method' => 'GET', 'url' => '/session/:sessionId/window'],
+        DriverCommand::GET_ELEMENT_LOCATION => ['method' => 'GET', 'url' => '/session/:sessionId/element/:id/rect'],
+        DriverCommand::GET_ELEMENT_PROPERTY => [
+            'method' => 'GET',
+            'url' => '/session/:sessionId/element/:id/property/:name',
+        ],
+        DriverCommand::GET_ELEMENT_SIZE => ['method' => 'GET', 'url' => '/session/:sessionId/element/:id/rect'],
+        DriverCommand::GET_WINDOW_HANDLES => ['method' => 'GET', 'url' => '/session/:sessionId/window/handles'],
+        DriverCommand::GET_ALERT_TEXT => ['method' => 'GET', 'url' => '/session/:sessionId/alert/text'],
+        DriverCommand::IMPLICITLY_WAIT => ['method' => 'POST', 'url' => '/session/:sessionId/timeouts'],
+        DriverCommand::SET_ALERT_VALUE => ['method' => 'POST', 'url' => '/session/:sessionId/alert/text'],
+        DriverCommand::SET_SCRIPT_TIMEOUT => ['method' => 'POST', 'url' => '/session/:sessionId/timeouts'],
+        DriverCommand::SET_TIMEOUT => ['method' => 'POST', 'url' => '/session/:sessionId/timeouts'],
+    ];
+    /**
      * @var string
      */
     protected $url;
@@ -145,6 +168,10 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
      * @var resource
      */
     protected $curl;
+    /**
+     * @var bool
+     */
+    protected $w3cCompliant = true;
 
     /**
      * @param string $url
@@ -153,6 +180,8 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
      */
     public function __construct($url, $http_proxy = null, $http_proxy_port = null)
     {
+        self::$w3cCompliantCommands = array_merge(self::$commands, self::$w3cCompliantCommands);
+
         $this->url = $url;
         $this->curl = curl_init();
 
@@ -177,6 +206,11 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         curl_setopt($this->curl, CURLOPT_HTTPHEADER, static::DEFAULT_HTTP_HEADERS);
         $this->setRequestTimeout(30000);
         $this->setConnectionTimeout(30000);
+    }
+
+    public function disableW3CCompliance()
+    {
+        $this->w3cCompliant = false;
     }
 
     /**
@@ -226,11 +260,19 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
      */
     public function execute(WebDriverCommand $command)
     {
-        if (!isset(self::$commands[$command->getName()])) {
-            throw new InvalidArgumentException($command->getName() . ' is not a valid command.');
+        $commandName = $command->getName();
+        if (!isset(self::$commands[$commandName])) {
+            if ($this->w3cCompliant && !isset(self::$w3cCompliantCommands[$commandName])) {
+                throw new InvalidArgumentException($command->getName() . ' is not a valid command.');
+            }
         }
 
-        $raw = self::$commands[$command->getName()];
+        if ($this->w3cCompliant) {
+            $raw = self::$w3cCompliantCommands[$command->getName()];
+        } else {
+            $raw = self::$commands[$command->getName()];
+        }
+
         $http_method = $raw['method'];
         $url = $raw['url'];
         $url = str_replace(':sessionId', $command->getSessionID(), $url);
@@ -317,12 +359,23 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         }
 
         $sessionId = null;
-        if (is_array($results) && array_key_exists('sessionId', $results)) {
+        if (is_array($value) && array_key_exists('sessionId', $value)) {
+            // W3C's WebDriver
+            $sessionId = $value['sessionId'];
+        } elseif (is_array($results) && array_key_exists('sessionId', $results)) {
+            // Legacy JsonWire
             $sessionId = $results['sessionId'];
         }
 
+        // @see https://w3c.github.io/webdriver/webdriver-spec.html#handling-errors
+        if (isset($value['error'])) {
+            // W3C's WebDriver
+            WebDriverException::throwException($value['error'], $message, $results);
+        }
+
         $status = isset($results['status']) ? $results['status'] : 0;
-        if ($status != 0) {
+        if ($status !== 0) {
+            // Legacy JsonWire
             WebDriverException::throwException($status, $message, $results);
         }
 

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -171,7 +171,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
     /**
      * @var bool
      */
-    protected $w3cCompliant = true;
+    protected $isW3cCompliant = true;
 
     /**
      * @param string $url
@@ -208,9 +208,9 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         $this->setConnectionTimeout(30000);
     }
 
-    public function disableW3CCompliance()
+    public function disableW3cCompliance()
     {
-        $this->w3cCompliant = false;
+        $this->isW3cCompliant = false;
     }
 
     /**
@@ -262,12 +262,12 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
     {
         $commandName = $command->getName();
         if (!isset(self::$commands[$commandName])) {
-            if ($this->w3cCompliant && !isset(self::$w3cCompliantCommands[$commandName])) {
+            if ($this->isW3cCompliant && !isset(self::$w3cCompliantCommands[$commandName])) {
                 throw new InvalidArgumentException($command->getName() . ' is not a valid command.');
             }
         }
 
-        if ($this->w3cCompliant) {
+        if ($this->isW3cCompliant) {
             $raw = self::$w3cCompliantCommands[$command->getName()];
         } else {
             $raw = self::$commands[$command->getName()];
@@ -316,7 +316,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         if ($http_method === 'POST') {
             if ($params && is_array($params)) {
                 $encoded_params = json_encode($params);
-            } elseif ($this->w3cCompliant) {
+            } elseif ($this->isW3cCompliant) {
                 // POST body must be valid JSON in W3C, even if empty: https://www.w3.org/TR/webdriver/#processing-model
                 $encoded_params = '{}';
             }

--- a/lib/Remote/JsonWireCompat.php
+++ b/lib/Remote/JsonWireCompat.php
@@ -1,0 +1,102 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Facebook\WebDriver\Remote;
+
+use Facebook\WebDriver\WebDriverBy;
+
+/**
+ * Compatibility layer between W3C's WebDriver and the legacy JsonWire protocol.
+ *
+ * @internal
+ */
+abstract class JsonWireCompat
+{
+    /**
+     * Element identifier defined in the W3C's WebDriver protocol.
+     *
+     * @see https://w3c.github.io/webdriver/webdriver-spec.html#elements
+     */
+    const WEB_DRIVER_ELEMENT_IDENTIFIER = 'element-6066-11e4-a52e-4f735466cecf';
+
+    public static function getElement(array $rawElement)
+    {
+        if (array_key_exists(self::WEB_DRIVER_ELEMENT_IDENTIFIER, $rawElement)) {
+            // W3C's WebDriver
+            return $rawElement[self::WEB_DRIVER_ELEMENT_IDENTIFIER];
+        }
+
+        // Legacy JsonWire
+        return $rawElement['ELEMENT'];
+    }
+
+    /**
+     * @param WebDriverBy $by
+     * @param bool $w3cCompliant
+     *
+     * @return array
+     */
+    public static function getUsing(WebDriverBy $by, $w3cCompliant)
+    {
+        $mechanism = $by->getMechanism();
+        $value = $by->getValue();
+
+        if ($w3cCompliant) {
+            switch ($mechanism) {
+                // Convert to CSS selectors
+                case 'class name':
+                    $mechanism = 'css selector';
+                    $value = sprintf('.%s', self::escapeSelector($value));
+                    break;
+                case 'id':
+                    $mechanism = 'css selector';
+                    $value = sprintf('#%s', self::escapeSelector($value));
+                    break;
+                case 'name':
+                    $mechanism = 'css selector';
+                    $value = sprintf('[name=\'%s\']', self::escapeSelector($value));
+                    break;
+            }
+        }
+
+        return ['using' => $mechanism, 'value' => $value];
+    }
+
+    /**
+     * Escapes a CSS selector.
+     *
+     * Code adapted from the Zend Escaper project.
+     *
+     * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+     * @see https://github.com/zendframework/zend-escaper/blob/master/src/Escaper.php
+     *
+     * @param string $selector
+     * @return string
+     */
+    private static function escapeSelector($selector)
+    {
+        return preg_replace_callback('/[^a-z0-9]/iSu', function ($matches) {
+            $chr = $matches[0];
+            if (mb_strlen($chr) == 1) {
+                $ord = ord($chr);
+            } else {
+                $chr = mb_convert_encoding($chr, 'UTF-32BE', 'UTF-8');
+                $ord = hexdec(bin2hex($chr));
+            }
+
+            return sprintf('\\%X ', $ord);
+        }, $selector);
+    }
+}

--- a/lib/Remote/JsonWireCompat.php
+++ b/lib/Remote/JsonWireCompat.php
@@ -44,16 +44,16 @@ abstract class JsonWireCompat
 
     /**
      * @param WebDriverBy $by
-     * @param bool $w3cCompliant
+     * @param bool $isW3cCompliant
      *
      * @return array
      */
-    public static function getUsing(WebDriverBy $by, $w3cCompliant)
+    public static function getUsing(WebDriverBy $by, $isW3cCompliant)
     {
         $mechanism = $by->getMechanism();
         $value = $by->getValue();
 
-        if ($w3cCompliant) {
+        if ($isW3cCompliant) {
             switch ($mechanism) {
                 // Convert to CSS selectors
                 case 'class name':
@@ -89,7 +89,7 @@ abstract class JsonWireCompat
     {
         return preg_replace_callback('/[^a-z0-9]/iSu', function ($matches) {
             $chr = $matches[0];
-            if (mb_strlen($chr) == 1) {
+            if (mb_strlen($chr) === 1) {
                 $ord = ord($chr);
             } else {
                 $chr = mb_convert_encoding($chr, 'UTF-32BE', 'UTF-8');

--- a/lib/Remote/RemoteMouse.php
+++ b/lib/Remote/RemoteMouse.php
@@ -30,16 +30,16 @@ class RemoteMouse implements WebDriverMouse
     /**
      * @var bool
      */
-    private $w3cCompliant;
+    private $isW3cCompliant;
 
     /**
      * @param RemoteExecuteMethod $executor
-     * @param bool $w3cCompliant
+     * @param bool $isW3cCompliant
      */
-    public function __construct(RemoteExecuteMethod $executor, $w3cCompliant = false)
+    public function __construct(RemoteExecuteMethod $executor, $isW3cCompliant = false)
     {
         $this->executor = $executor;
-        $this->w3cCompliant = $w3cCompliant;
+        $this->isW3cCompliant = $isW3cCompliant;
     }
 
     /**
@@ -49,7 +49,7 @@ class RemoteMouse implements WebDriverMouse
      */
     public function click(WebDriverCoordinates $where = null)
     {
-        if ($this->w3cCompliant) {
+        if ($this->isW3cCompliant) {
             $moveAction = $where ? [$this->createMoveAction($where)] : [];
             $this->executor->execute(DriverCommand::ACTIONS, [
                 'actions' => [
@@ -80,7 +80,7 @@ class RemoteMouse implements WebDriverMouse
      */
     public function contextClick(WebDriverCoordinates $where = null)
     {
-        if ($this->w3cCompliant) {
+        if ($this->isW3cCompliant) {
             $moveAction = $where ? [$this->createMoveAction($where)] : [];
             $this->executor->execute(DriverCommand::ACTIONS, [
                 'actions' => [
@@ -122,7 +122,7 @@ class RemoteMouse implements WebDriverMouse
      */
     public function doubleClick(WebDriverCoordinates $where = null)
     {
-        if ($this->w3cCompliant) {
+        if ($this->isW3cCompliant) {
             $clickActions = $this->createClickActions();
             $moveAction = null === $where ? [] : [$this->createMoveAction($where)];
             $this->executor->execute(DriverCommand::ACTIONS, [
@@ -152,7 +152,7 @@ class RemoteMouse implements WebDriverMouse
      */
     public function mouseDown(WebDriverCoordinates $where = null)
     {
-        if ($this->w3cCompliant) {
+        if ($this->isW3cCompliant) {
             $this->executor->execute(DriverCommand::ACTIONS, [
                 'actions' => [
                     [
@@ -192,7 +192,7 @@ class RemoteMouse implements WebDriverMouse
         $x_offset = null,
         $y_offset = null
     ) {
-        if ($this->w3cCompliant) {
+        if ($this->isW3cCompliant) {
             $this->executor->execute(DriverCommand::ACTIONS, [
                 'actions' => [
                     [
@@ -230,7 +230,7 @@ class RemoteMouse implements WebDriverMouse
      */
     public function mouseUp(WebDriverCoordinates $where = null)
     {
-        if ($this->w3cCompliant) {
+        if ($this->isW3cCompliant) {
             $moveAction = $where ? [$this->createMoveAction($where)] : [];
 
             $this->executor->execute(DriverCommand::ACTIONS, [

--- a/lib/Remote/RemoteTargetLocator.php
+++ b/lib/Remote/RemoteTargetLocator.php
@@ -112,6 +112,8 @@ class RemoteTargetLocator implements WebDriverTargetLocator
         $response = $this->driver->execute(DriverCommand::GET_ACTIVE_ELEMENT, []);
         $method = new RemoteExecuteMethod($this->driver);
 
-        return new RemoteWebElement($method, $response['ELEMENT']);
+        $w3cCompliant = $this->driver instanceof RemoteWebDriver ? $this->driver->isW3cCompliant() : false;
+
+        return new RemoteWebElement($method, JsonWireCompat::getElement($response), $w3cCompliant);
     }
 }

--- a/lib/Remote/RemoteTargetLocator.php
+++ b/lib/Remote/RemoteTargetLocator.php
@@ -112,8 +112,8 @@ class RemoteTargetLocator implements WebDriverTargetLocator
         $response = $this->driver->execute(DriverCommand::GET_ACTIVE_ELEMENT, []);
         $method = new RemoteExecuteMethod($this->driver);
 
-        $w3cCompliant = $this->driver instanceof RemoteWebDriver ? $this->driver->isW3cCompliant() : false;
+        $isW3cCompliant = ($this->driver instanceof RemoteWebDriver) ? $this->driver->isW3cCompliant() : false;
 
-        return new RemoteWebElement($method, JsonWireCompat::getElement($response), $w3cCompliant);
+        return new RemoteWebElement($method, JsonWireCompat::getElement($response), $isW3cCompliant);
     }
 }

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -59,19 +59,26 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      * @var RemoteExecuteMethod
      */
     protected $executeMethod;
+    /**
+     * @var bool
+     */
+    protected $w3cCompliant;
 
     /**
      * @param HttpCommandExecutor $commandExecutor
      * @param string $sessionId
      * @param WebDriverCapabilities|null $capabilities
+     * @param bool $w3cCompliant false to use the legacy JsonWire protocol, true for the W3C WebDriver spec
      */
     protected function __construct(
         HttpCommandExecutor $commandExecutor,
         $sessionId,
-        WebDriverCapabilities $capabilities = null
+        WebDriverCapabilities $capabilities = null,
+        $w3cCompliant = false
     ) {
         $this->executor = $commandExecutor;
         $this->sessionID = $sessionId;
+        $this->w3cCompliant = $w3cCompliant;
 
         if ($capabilities !== null) {
             $this->capabilities = $capabilities;
@@ -88,6 +95,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      * @param string|null $http_proxy The proxy to tunnel requests to the remote Selenium WebDriver through
      * @param int|null $http_proxy_port The proxy port to tunnel requests to the remote Selenium WebDriver through
      * @param DesiredCapabilities $required_capabilities The required capabilities
+     *
      * @return static
      */
     public static function create(
@@ -99,6 +107,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         $http_proxy_port = null,
         DesiredCapabilities $required_capabilities = null
     ) {
+        // BC layer to not break the method signature
         $selenium_server_url = preg_replace('#/+$#', '', $selenium_server_url);
 
         $desired_capabilities = self::castToDesiredCapabilitiesObject($desired_capabilities);
@@ -128,23 +137,43 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
             $executor->setRequestTimeout($request_timeout_in_ms);
         }
 
+        // W3C
+        $parameters = [
+            'capabilities' => [
+                'firstMatch' => [$desired_capabilities->toArray()],
+            ],
+        ];
+
+        // Legacy protocol
+        if (null !== $required_capabilities && $required_capabilities_array = $required_capabilities->toArray()) {
+            $parameters['capabilities']['alwaysMatch'] = $required_capabilities_array;
+        }
+
         if ($required_capabilities !== null) {
             // TODO: Selenium (as of v3.0.1) does accept requiredCapabilities only as a property of desiredCapabilities.
-            // This will probably change in future with the W3C WebDriver spec, but is the only way how to pass these
-            // values now.
+            // This has changed with the W3C WebDriver spec, but is the only way how to pass these
+            // values with the legacy protocol.
             $desired_capabilities->setCapability('requiredCapabilities', $required_capabilities->toArray());
         }
+
+        $parameters['desiredCapabilities'] = $desired_capabilities->toArray();
 
         $command = new WebDriverCommand(
             null,
             DriverCommand::NEW_SESSION,
-            ['desiredCapabilities' => $desired_capabilities->toArray()]
+            $parameters
         );
 
         $response = $executor->execute($command);
-        $returnedCapabilities = new DesiredCapabilities($response->getValue());
+        $value = $response->getValue();
 
-        $driver = new static($executor, $response->getSessionID(), $returnedCapabilities);
+        if (!$w3c_compliant = isset($value['capabilities'])) {
+            $executor->disableW3CCompliance();
+        }
+
+        $returnedCapabilities = new DesiredCapabilities($w3c_compliant ? $value['capabilities'] : $value);
+
+        $driver = new static($executor, $response->getSessionID(), $returnedCapabilities, $w3c_compliant);
 
         return $driver;
     }
@@ -167,7 +196,9 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         $connection_timeout_in_ms = null,
         $request_timeout_in_ms = null
     ) {
-        $executor = new HttpCommandExecutor($selenium_server_url);
+        // BC layer to not break the method signature
+        $w3c_compliant = func_num_args() > 3 ? func_get_arg(3) : false;
+        $executor = new HttpCommandExecutor($selenium_server_url, null, null);
         if ($connection_timeout_in_ms !== null) {
             $executor->setConnectionTimeout($connection_timeout_in_ms);
         }
@@ -175,7 +206,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
             $executor->setRequestTimeout($request_timeout_in_ms);
         }
 
-        return new static($executor, $session_id);
+        return new static($executor, $session_id, null, $w3c_compliant);
     }
 
     /**
@@ -199,13 +230,12 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      */
     public function findElement(WebDriverBy $by)
     {
-        $params = ['using' => $by->getMechanism(), 'value' => $by->getValue()];
         $raw_element = $this->execute(
             DriverCommand::FIND_ELEMENT,
-            $params
+            JsonWireCompat::getUsing($by, $this->w3cCompliant)
         );
 
-        return $this->newElement($raw_element['ELEMENT']);
+        return $this->newElement(JsonWireCompat::getElement($raw_element));
     }
 
     /**
@@ -217,15 +247,14 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      */
     public function findElements(WebDriverBy $by)
     {
-        $params = ['using' => $by->getMechanism(), 'value' => $by->getValue()];
         $raw_elements = $this->execute(
             DriverCommand::FIND_ELEMENTS,
-            $params
+            JsonWireCompat::getUsing($by, $this->w3cCompliant)
         );
 
         $elements = [];
         foreach ($raw_elements as $raw_element) {
-            $elements[] = $this->newElement($raw_element['ELEMENT']);
+            $elements[] = $this->newElement(JsonWireCompat::getElement($raw_element));
         }
 
         return $elements;
@@ -399,7 +428,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      */
     public function manage()
     {
-        return new WebDriverOptions($this->getExecuteMethod());
+        return new WebDriverOptions($this->getExecuteMethod(), $this->w3cCompliant);
     }
 
     /**
@@ -430,7 +459,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     public function getMouse()
     {
         if (!$this->mouse) {
-            $this->mouse = new RemoteMouse($this->getExecuteMethod());
+            $this->mouse = new RemoteMouse($this->getExecuteMethod(), $this->w3cCompliant);
         }
 
         return $this->mouse;
@@ -541,7 +570,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      */
     public static function getAllSessions($selenium_server_url = 'http://localhost:4444/wd/hub', $timeout_in_ms = 30000)
     {
-        $executor = new HttpCommandExecutor($selenium_server_url);
+        $executor = new HttpCommandExecutor($selenium_server_url, null, null);
         $executor->setConnectionTimeout($timeout_in_ms);
 
         $command = new WebDriverCommand(
@@ -571,6 +600,15 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     }
 
     /**
+     * @internal
+     * @return bool
+     */
+    public function isW3cCompliant()
+    {
+        return $this->w3cCompliant;
+    }
+
+    /**
      * Prepare arguments for JavaScript injection
      *
      * @param array $arguments
@@ -581,9 +619,11 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         $args = [];
         foreach ($arguments as $key => $value) {
             if ($value instanceof WebDriverElement) {
-                $args[$key] = ['ELEMENT' => $value->getID()];
+                $args[$key] = [
+                    $this->w3cCompliant ? JsonWireCompat::WEB_DRIVER_ELEMENT_IDENTIFIER : 'ELEMENT' => $value->getID(),
+                ];
             } else {
-                if (is_array($value)) {
+                if (\is_array($value)) {
                     $value = $this->prepareScriptArguments($value);
                 }
                 $args[$key] = $value;
@@ -613,7 +653,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      */
     protected function newElement($id)
     {
-        return new RemoteWebElement($this->getExecuteMethod(), $id);
+        return new RemoteWebElement($this->getExecuteMethod(), $id, $this->w3cCompliant);
     }
 
     /**
@@ -629,7 +669,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
             return new DesiredCapabilities();
         }
 
-        if (is_array($desired_capabilities)) {
+        if (\is_array($desired_capabilities)) {
             return new DesiredCapabilities($desired_capabilities);
         }
 

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -62,23 +62,23 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     /**
      * @var bool
      */
-    protected $w3cCompliant;
+    protected $isW3cCompliant;
 
     /**
      * @param HttpCommandExecutor $commandExecutor
      * @param string $sessionId
      * @param WebDriverCapabilities|null $capabilities
-     * @param bool $w3cCompliant false to use the legacy JsonWire protocol, true for the W3C WebDriver spec
+     * @param bool $isW3cCompliant false to use the legacy JsonWire protocol, true for the W3C WebDriver spec
      */
     protected function __construct(
         HttpCommandExecutor $commandExecutor,
         $sessionId,
         WebDriverCapabilities $capabilities = null,
-        $w3cCompliant = false
+        $isW3cCompliant = false
     ) {
         $this->executor = $commandExecutor;
         $this->sessionID = $sessionId;
-        $this->w3cCompliant = $w3cCompliant;
+        $this->isW3cCompliant = $isW3cCompliant;
 
         if ($capabilities !== null) {
             $this->capabilities = $capabilities;
@@ -168,7 +168,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         $value = $response->getValue();
 
         if (!$w3c_compliant = isset($value['capabilities'])) {
-            $executor->disableW3CCompliance();
+            $executor->disableW3cCompliance();
         }
 
         $returnedCapabilities = new DesiredCapabilities($w3c_compliant ? $value['capabilities'] : $value);
@@ -232,7 +232,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     {
         $raw_element = $this->execute(
             DriverCommand::FIND_ELEMENT,
-            JsonWireCompat::getUsing($by, $this->w3cCompliant)
+            JsonWireCompat::getUsing($by, $this->isW3cCompliant)
         );
 
         return $this->newElement(JsonWireCompat::getElement($raw_element));
@@ -249,7 +249,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     {
         $raw_elements = $this->execute(
             DriverCommand::FIND_ELEMENTS,
-            JsonWireCompat::getUsing($by, $this->w3cCompliant)
+            JsonWireCompat::getUsing($by, $this->isW3cCompliant)
         );
 
         $elements = [];
@@ -428,7 +428,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      */
     public function manage()
     {
-        return new WebDriverOptions($this->getExecuteMethod(), $this->w3cCompliant);
+        return new WebDriverOptions($this->getExecuteMethod(), $this->isW3cCompliant);
     }
 
     /**
@@ -459,7 +459,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     public function getMouse()
     {
         if (!$this->mouse) {
-            $this->mouse = new RemoteMouse($this->getExecuteMethod(), $this->w3cCompliant);
+            $this->mouse = new RemoteMouse($this->getExecuteMethod(), $this->isW3cCompliant);
         }
 
         return $this->mouse;
@@ -605,7 +605,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      */
     public function isW3cCompliant()
     {
-        return $this->w3cCompliant;
+        return $this->isW3cCompliant;
     }
 
     /**
@@ -620,10 +620,12 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         foreach ($arguments as $key => $value) {
             if ($value instanceof WebDriverElement) {
                 $args[$key] = [
-                    $this->w3cCompliant ? JsonWireCompat::WEB_DRIVER_ELEMENT_IDENTIFIER : 'ELEMENT' => $value->getID(),
+                    $this->isW3cCompliant ?
+                        JsonWireCompat::WEB_DRIVER_ELEMENT_IDENTIFIER
+                        : 'ELEMENT' => $value->getID(),
                 ];
             } else {
-                if (\is_array($value)) {
+                if (is_array($value)) {
                     $value = $this->prepareScriptArguments($value);
                 }
                 $args[$key] = $value;
@@ -653,7 +655,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      */
     protected function newElement($id)
     {
-        return new RemoteWebElement($this->getExecuteMethod(), $id, $this->w3cCompliant);
+        return new RemoteWebElement($this->getExecuteMethod(), $id, $this->isW3cCompliant);
     }
 
     /**
@@ -669,7 +671,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
             return new DesiredCapabilities();
         }
 
-        if (\is_array($desired_capabilities)) {
+        if (is_array($desired_capabilities)) {
             return new DesiredCapabilities($desired_capabilities);
         }
 

--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -46,19 +46,19 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
     /**
      * @var bool
      */
-    protected $w3cCompliant;
+    protected $isW3cCompliant;
 
     /**
      * @param RemoteExecuteMethod $executor
      * @param string $id
-     * @param bool $w3cCompliant
+     * @param bool $isW3cCompliant
      */
-    public function __construct(RemoteExecuteMethod $executor, $id, $w3cCompliant = false)
+    public function __construct(RemoteExecuteMethod $executor, $id, $isW3cCompliant = false)
     {
         $this->executor = $executor;
         $this->id = $id;
         $this->fileDetector = new UselessFileDetector();
-        $this->w3cCompliant = $w3cCompliant;
+        $this->isW3cCompliant = $isW3cCompliant;
     }
 
     /**
@@ -73,20 +73,22 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
             [':id' => $this->id]
         );
 
-        if ($this->w3cCompliant) {
+        if ($this->isW3cCompliant) {
             $this->executor->execute(DriverCommand::ACTIONS, [
-                'actions' => [[
-                    'type' => 'key',
-                    'id' => 'keyboard',
-                    'actions' => [
-                        ['type' => 'keyDown' , 'value' => WebDriverKeys::CONTROL],
-                        ['type' => 'keyDown' , 'value' => 'a'],
-                        ['type' => 'keyUp' , 'value' => WebDriverKeys::CONTROL],
-                        ['type' => 'keyUp' , 'value' => 'a'],
-                        ['type' => 'keyDown' , 'value' => WebDriverKeys::BACKSPACE],
-                        ['type' => 'keyUp' , 'value' => WebDriverKeys::BACKSPACE],
+                'actions' => [
+                    [
+                        'type' => 'key',
+                        'id' => 'keyboard',
+                        'actions' => [
+                            ['type' => 'keyDown', 'value' => WebDriverKeys::CONTROL],
+                            ['type' => 'keyDown', 'value' => 'a'],
+                            ['type' => 'keyUp', 'value' => WebDriverKeys::CONTROL],
+                            ['type' => 'keyUp', 'value' => 'a'],
+                            ['type' => 'keyDown', 'value' => WebDriverKeys::BACKSPACE],
+                            ['type' => 'keyUp', 'value' => WebDriverKeys::BACKSPACE],
+                        ],
                     ],
-                ]],
+                ],
             ]);
         }
 
@@ -118,7 +120,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
      */
     public function findElement(WebDriverBy $by)
     {
-        $params = JsonWireCompat::getUsing($by, $this->w3cCompliant);
+        $params = JsonWireCompat::getUsing($by, $this->isW3cCompliant);
         $params[':id'] = $this->id;
 
         $raw_element = $this->executor->execute(
@@ -139,7 +141,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
      */
     public function findElements(WebDriverBy $by)
     {
-        $params = JsonWireCompat::getUsing($by, $this->w3cCompliant);
+        $params = JsonWireCompat::getUsing($by, $this->isW3cCompliant);
         $params[':id'] = $this->id;
         $raw_elements = $this->executor->execute(
             DriverCommand::FIND_CHILD_ELEMENTS,
@@ -167,7 +169,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
             ':id' => $this->id,
         ];
 
-        if ($this->w3cCompliant && ($attribute_name === 'value' || $attribute_name === 'index')) {
+        if ($this->isW3cCompliant && ($attribute_name === 'value' || $attribute_name === 'index')) {
             $value = $this->executor->execute(DriverCommand::GET_ELEMENT_PROPERTY, $params);
 
             if ($value === true) {
@@ -357,7 +359,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
     {
         $local_file = $this->fileDetector->getLocalFile($value);
         if ($local_file === null) {
-            if ($this->w3cCompliant) {
+            if ($this->isW3cCompliant) {
                 $params = [
                     'text' => (string) $value,
                     ':id' => $this->id,
@@ -374,7 +376,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
             return $this;
         }
 
-        if ($this->w3cCompliant) {
+        if ($this->isW3cCompliant) {
             $params = [
                 'text' => $local_file,
                 ':id' => $this->id,
@@ -420,7 +422,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
      */
     public function submit()
     {
-        if ($this->w3cCompliant) {
+        if ($this->isW3cCompliant) {
             $this->executor->execute(DriverCommand::EXECUTE_SCRIPT, [
                 // cannot call the submit method directly in case an input of this form is named "submit"
                 'script' => sprintf(
@@ -459,7 +461,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
      */
     public function equals(WebDriverElement $other)
     {
-        if ($this->w3cCompliant) {
+        if ($this->isW3cCompliant) {
             throw new UnsupportedOperationException('"elementEquals" is not supported by the W3C specification');
         }
 
@@ -478,7 +480,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
      */
     protected function newElement($id)
     {
-        return new static($this->executor, $id, $this->w3cCompliant);
+        return new static($this->executor, $id, $this->isW3cCompliant);
     }
 
     /**

--- a/lib/WebDriverDimension.php
+++ b/lib/WebDriverDimension.php
@@ -21,17 +21,17 @@ namespace Facebook\WebDriver;
 class WebDriverDimension
 {
     /**
-     * @var int
+     * @var int|float
      */
     private $height;
     /**
-     * @var int
+     * @var int|float
      */
     private $width;
 
     /**
-     * @param int $width
-     * @param int $height
+     * @param int|float $width
+     * @param int|float $height
      */
     public function __construct($width, $height)
     {
@@ -46,7 +46,7 @@ class WebDriverDimension
      */
     public function getHeight()
     {
-        return $this->height;
+        return (int) $this->height;
     }
 
     /**
@@ -56,7 +56,7 @@ class WebDriverDimension
      */
     public function getWidth()
     {
-        return $this->width;
+        return (int) $this->width;
     }
 
     /**

--- a/lib/WebDriverOptions.php
+++ b/lib/WebDriverOptions.php
@@ -28,10 +28,15 @@ class WebDriverOptions
      * @var ExecuteMethod
      */
     protected $executor;
+    /**
+     * @var bool
+     */
+    protected $w3cCompliant;
 
-    public function __construct(ExecuteMethod $executor)
+    public function __construct(ExecuteMethod $executor, $w3cCompliant = false)
     {
         $this->executor = $executor;
+        $this->w3cCompliant = $w3cCompliant;
     }
 
     /**
@@ -128,7 +133,7 @@ class WebDriverOptions
      */
     public function timeouts()
     {
-        return new WebDriverTimeouts($this->executor);
+        return new WebDriverTimeouts($this->executor, $this->w3cCompliant);
     }
 
     /**

--- a/lib/WebDriverOptions.php
+++ b/lib/WebDriverOptions.php
@@ -31,12 +31,12 @@ class WebDriverOptions
     /**
      * @var bool
      */
-    protected $w3cCompliant;
+    protected $isW3cCompliant;
 
-    public function __construct(ExecuteMethod $executor, $w3cCompliant = false)
+    public function __construct(ExecuteMethod $executor, $isW3cCompliant = false)
     {
         $this->executor = $executor;
-        $this->w3cCompliant = $w3cCompliant;
+        $this->isW3cCompliant = $isW3cCompliant;
     }
 
     /**
@@ -133,7 +133,7 @@ class WebDriverOptions
      */
     public function timeouts()
     {
-        return new WebDriverTimeouts($this->executor, $this->w3cCompliant);
+        return new WebDriverTimeouts($this->executor, $this->isW3cCompliant);
     }
 
     /**

--- a/lib/WebDriverPoint.php
+++ b/lib/WebDriverPoint.php
@@ -36,7 +36,7 @@ class WebDriverPoint
      */
     public function getX()
     {
-        return $this->x;
+        return (int) $this->x;
     }
 
     /**
@@ -46,7 +46,7 @@ class WebDriverPoint
      */
     public function getY()
     {
-        return $this->y;
+        return (int) $this->y;
     }
 
     /**

--- a/lib/WebDriverTimeouts.php
+++ b/lib/WebDriverTimeouts.php
@@ -27,10 +27,15 @@ class WebDriverTimeouts
      * @var ExecuteMethod
      */
     protected $executor;
+    /**
+     * @var bool
+     */
+    protected $w3cCompliant;
 
-    public function __construct(ExecuteMethod $executor)
+    public function __construct(ExecuteMethod $executor, $w3cCompliant = false)
     {
         $this->executor = $executor;
+        $this->w3cCompliant = $w3cCompliant;
     }
 
     /**
@@ -41,6 +46,15 @@ class WebDriverTimeouts
      */
     public function implicitlyWait($seconds)
     {
+        if ($this->w3cCompliant) {
+            $this->executor->execute(
+                DriverCommand::IMPLICITLY_WAIT,
+                ['implicit' => $seconds * 1000]
+            );
+
+            return $this;
+        }
+
         $this->executor->execute(
             DriverCommand::IMPLICITLY_WAIT,
             ['ms' => $seconds * 1000]
@@ -57,6 +71,15 @@ class WebDriverTimeouts
      */
     public function setScriptTimeout($seconds)
     {
+        if ($this->w3cCompliant) {
+            $this->executor->execute(
+                DriverCommand::SET_SCRIPT_TIMEOUT,
+                ['script' => $seconds * 1000]
+            );
+
+            return $this;
+        }
+
         $this->executor->execute(
             DriverCommand::SET_SCRIPT_TIMEOUT,
             ['ms' => $seconds * 1000]
@@ -73,6 +96,15 @@ class WebDriverTimeouts
      */
     public function pageLoadTimeout($seconds)
     {
+        if ($this->w3cCompliant) {
+            $this->executor->execute(
+                DriverCommand::SET_SCRIPT_TIMEOUT,
+                ['pageLoad' => $seconds * 1000]
+            );
+
+            return $this;
+        }
+
         $this->executor->execute(DriverCommand::SET_TIMEOUT, [
             'type' => 'page load',
             'ms' => $seconds * 1000,

--- a/lib/WebDriverTimeouts.php
+++ b/lib/WebDriverTimeouts.php
@@ -30,12 +30,12 @@ class WebDriverTimeouts
     /**
      * @var bool
      */
-    protected $w3cCompliant;
+    protected $isW3cCompliant;
 
-    public function __construct(ExecuteMethod $executor, $w3cCompliant = false)
+    public function __construct(ExecuteMethod $executor, $isW3cCompliant = false)
     {
         $this->executor = $executor;
-        $this->w3cCompliant = $w3cCompliant;
+        $this->isW3cCompliant = $isW3cCompliant;
     }
 
     /**
@@ -46,7 +46,7 @@ class WebDriverTimeouts
      */
     public function implicitlyWait($seconds)
     {
-        if ($this->w3cCompliant) {
+        if ($this->isW3cCompliant) {
             $this->executor->execute(
                 DriverCommand::IMPLICITLY_WAIT,
                 ['implicit' => $seconds * 1000]
@@ -71,7 +71,7 @@ class WebDriverTimeouts
      */
     public function setScriptTimeout($seconds)
     {
-        if ($this->w3cCompliant) {
+        if ($this->isW3cCompliant) {
             $this->executor->execute(
                 DriverCommand::SET_SCRIPT_TIMEOUT,
                 ['script' => $seconds * 1000]
@@ -96,7 +96,7 @@ class WebDriverTimeouts
      */
     public function pageLoadTimeout($seconds)
     {
-        if ($this->w3cCompliant) {
+        if ($this->isW3cCompliant) {
             $this->executor->execute(
                 DriverCommand::SET_SCRIPT_TIMEOUT,
                 ['pageLoad' => $seconds * 1000]

--- a/tests/functional/RemoteWebDriverCreateTest.php
+++ b/tests/functional/RemoteWebDriverCreateTest.php
@@ -33,7 +33,10 @@ class RemoteWebDriverCreateTest extends WebDriverTestCase
             $this->serverUrl,
             $this->desiredCapabilities,
             $this->connectionTimeout,
-            $this->requestTimeout
+            $this->requestTimeout,
+            null,
+            null,
+            null
         );
 
         $this->assertInstanceOf(RemoteWebDriver::class, $this->driver);

--- a/tests/functional/RemoteWebDriverFindElementTest.php
+++ b/tests/functional/RemoteWebDriverFindElementTest.php
@@ -61,4 +61,24 @@ class RemoteWebDriverFindElementTest extends WebDriverTestCase
         $this->assertCount(5, $elements);
         $this->assertContainsOnlyInstancesOf(RemoteWebElement::class, $elements);
     }
+
+    public function testEscapeCssSelector()
+    {
+        if (getenv('GECKODRIVER') !== '1') {
+            $this->markTestSkipped(
+                'CSS selectors containing special characters are not supported by the legacy protocol'
+            );
+        }
+
+        $this->driver->get($this->getTestPageUrl('escape_css.html'));
+
+        $element = $this->driver->findElement(WebDriverBy::id('.fo\'oo'));
+        $this->assertSame('Foo', $element->getText());
+
+        $element = $this->driver->findElement(WebDriverBy::className('#ba\'r'));
+        $this->assertSame('Bar', $element->getText());
+
+        $element = $this->driver->findElement(WebDriverBy::name('.#ba\'z'));
+        $this->assertSame('Baz', $element->getText());
+    }
 }

--- a/tests/functional/RemoteWebDriverTest.php
+++ b/tests/functional/RemoteWebDriverTest.php
@@ -77,7 +77,11 @@ class RemoteWebDriverTest extends WebDriverTestCase
      */
     public function testShouldGetAllSessions()
     {
-        $sessions = RemoteWebDriver::getAllSessions($this->serverUrl);
+        if (getenv('GECKODRIVER') === '1') {
+            $this->markTestSkipped('"getAllSessions" is not supported by the W3C specification');
+        }
+
+        $sessions = RemoteWebDriver::getAllSessions($this->serverUrl, 30000);
 
         $this->assertInternalType('array', $sessions);
         $this->assertCount(1, $sessions);
@@ -94,12 +98,22 @@ class RemoteWebDriverTest extends WebDriverTestCase
      */
     public function testShouldQuitAndUnsetExecutor()
     {
-        $this->assertCount(1, RemoteWebDriver::getAllSessions($this->serverUrl));
+        if (getenv('GECKODRIVER') === '1') {
+            $this->markTestSkipped('"getAllSessions" is not supported by the W3C specification');
+        }
+
+        $this->assertCount(
+            1,
+            RemoteWebDriver::getAllSessions($this->serverUrl, 30000)
+        );
         $this->assertInstanceOf(HttpCommandExecutor::class, $this->driver->getCommandExecutor());
 
         $this->driver->quit();
 
-        $this->assertCount(0, RemoteWebDriver::getAllSessions($this->serverUrl));
+        $this->assertCount(
+            0,
+            RemoteWebDriver::getAllSessions($this->serverUrl, 30000)
+        );
         $this->assertNull($this->driver->getCommandExecutor());
     }
 
@@ -135,6 +149,9 @@ class RemoteWebDriverTest extends WebDriverTestCase
     {
         $this->driver->get($this->getTestPageUrl('open_new_window.html'));
         $this->driver->findElement(WebDriverBy::cssSelector('a'))->click();
+
+        // Mandatory for Geckodriver
+        $this->driver->wait()->until(WebDriverExpectedCondition::numberOfWindowsToBe(2));
 
         $this->assertCount(2, $this->driver->getWindowHandles());
 

--- a/tests/functional/RemoteWebElementTest.php
+++ b/tests/functional/RemoteWebElementTest.php
@@ -272,6 +272,10 @@ class RemoteWebElementTest extends WebDriverTestCase
      */
     public function testShouldCompareEqualsElement()
     {
+        if (getenv('GECKODRIVER') === '1') {
+            $this->markTestSkipped('"equals" is not supported by the W3C specification');
+        }
+
         $this->driver->get($this->getTestPageUrl('index.html'));
 
         $firstElement = $this->driver->findElement(WebDriverBy::cssSelector('ul.list'));

--- a/tests/functional/WebDriverActionsTest.php
+++ b/tests/functional/WebDriverActionsTest.php
@@ -46,10 +46,16 @@ class WebDriverActionsTest extends WebDriverTestCase
             ->click($element)
             ->perform();
 
-        $this->assertSame(
-            ['mouseover item-1', 'mousedown item-1', 'mouseup item-1', 'click item-1'],
-            $this->retrieveLoggedEvents()
-        );
+        $logs = ['mouseover item-1', 'mousedown item-1', 'mouseup item-1', 'click item-1'];
+        $loggedEvents = $this->retrieveLoggedEvents();
+
+        if ('1' === getenv('GECKODRIVER')) {
+            $loggedEvents = array_slice($loggedEvents, 0, count($logs));
+            // Firefox sometimes triggers some extra events
+            // it's not related to Geckodriver, it's Firefox's own behavior
+        }
+
+        $this->assertSame($logs, $loggedEvents);
     }
 
     /**
@@ -71,10 +77,12 @@ class WebDriverActionsTest extends WebDriverTestCase
             ->release()
             ->perform();
 
-        $this->assertSame(
-            ['mouseover item-1', 'mousedown item-1', 'mouseup item-1', 'click item-1'],
-            $this->retrieveLoggedEvents()
-        );
+        if ('1' === getenv('GECKODRIVER')) {
+            $logs = ['mouseover item-1', 'mousedown item-1', 'dragstart item-1'];
+        } else {
+            $logs = ['mouseover item-1', 'mousedown item-1', 'mouseup item-1', 'click item-1'];
+        }
+        $this->assertSame($logs, $this->retrieveLoggedEvents());
     }
 
     /**

--- a/tests/functional/WebDriverActionsTest.php
+++ b/tests/functional/WebDriverActionsTest.php
@@ -78,11 +78,13 @@ class WebDriverActionsTest extends WebDriverTestCase
             ->perform();
 
         if ('1' === getenv('GECKODRIVER')) {
-            $logs = ['mouseover item-1', 'mousedown item-1', 'dragstart item-1'];
+            $this->assertArraySubset(['mouseover item-1', 'mousedown item-1'], $this->retrieveLoggedEvents());
         } else {
-            $logs = ['mouseover item-1', 'mousedown item-1', 'mouseup item-1', 'click item-1'];
+            $this->assertSame(
+                ['mouseover item-1', 'mousedown item-1', 'mouseup item-1', 'click item-1'],
+                $this->retrieveLoggedEvents()
+            );
         }
-        $this->assertSame($logs, $this->retrieveLoggedEvents());
     }
 
     /**

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -58,6 +58,8 @@ class WebDriverTestCase extends TestCase
                 // --no-sandbox is a workaround for Chrome crashing: https://github.com/SeleniumHQ/selenium/issues/4961
                 $chromeOptions->addArguments(['--headless', 'window-size=1024,768', '--no-sandbox']);
                 $this->desiredCapabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);
+            } elseif (getenv('GECKODRIVER') === '1') {
+                $this->serverUrl = 'http://localhost:4444';
             }
 
             $this->desiredCapabilities->setBrowserName($browserName);
@@ -68,7 +70,10 @@ class WebDriverTestCase extends TestCase
                 $this->serverUrl,
                 $this->desiredCapabilities,
                 $this->connectionTimeout,
-                $this->requestTimeout
+                $this->requestTimeout,
+                null,
+                null,
+                null
             );
         }
     }

--- a/tests/functional/web/escape_css.html
+++ b/tests/functional/web/escape_css.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Test CSS selector escaping</title>
+</head>
+<body>
+
+<div id=".fo'oo">Foo</div>
+<div class="#ba'r">Bar</div>
+<div name=".#ba'z">Baz</div>
+
+</body>
+</html>

--- a/tests/functional/web/upload.html
+++ b/tests/functional/web/upload.html
@@ -8,7 +8,7 @@
     <form method="post" action="upload.php" enctype="multipart/form-data">
         <p>
             <label for="upload">Select a file to upload:</label>
-            <input type="file" name="upload" id="upload"  />
+            <input type="file" name="upload" id="upload" />
         </p>
         <p>
             <input type="submit" name="submit" value="Submit"/>


### PR DESCRIPTION
This PR provides an implementation of [the W3C flavor of the WebDriver protocol](https://www.w3.org/TR/webdriver/).This implem is good enough to make the [Symfony Panther](https://github.com/symfony/panther)'s test suite green when using the latest version of [geckodriver](https://github.com/mozilla/geckodriver).
It is 100% backward compatible with the current (JsonWire) implementation.

The (only?) missing part is the capabilities support. It's a step to close #469.

TODO:

* [x] Add geckodriver in Travis to run the project's test suite against a valid implementation of the W3C protocol.

Subsequent work (in other PRs?):

* Add new classes for exceptions that wasn't part of JsonWire
* Add support for capabilities and other missing parts 