### PR TITLE
Mozilla firefox geckodriver fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ---
 
+### Fixed
+- Mozilla firefox geckodriver fix. ([PHPUnit\Framework\Exception] Undefined index: ELEMENT)
+
 ## 1.6.0 - 2018-05-16
 ### Added
 - Connection and request timeouts could be specified also when creating RemoteWebDriver from existing session ID.

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -187,7 +187,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
             $params
         );
 
-        return $this->newElement($raw_element['ELEMENT']);
+        return $this->newElement($raw_element['ELEMENT'] ?? $raw_element[\key($raw_element)]);
     }
 
     /**
@@ -207,7 +207,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
 
         $elements = [];
         foreach ($raw_elements as $raw_element) {
-            $elements[] = $this->newElement($raw_element['ELEMENT']);
+            $elements[] = $this->newElement($raw_element['ELEMENT'] ?? $raw_element[\key($raw_element)]);
         }
 
         return $elements;

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -187,7 +187,9 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
             $params
         );
 
-        return $this->newElement($raw_element['ELEMENT'] ?? $raw_element[\key($raw_element)]);
+        return $this->newElement(
+            isset($raw_element['ELEMENT']) ? $raw_element['ELEMENT'] : $raw_element[\key($raw_element)]
+        );
     }
 
     /**
@@ -207,7 +209,9 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
 
         $elements = [];
         foreach ($raw_elements as $raw_element) {
-            $elements[] = $this->newElement($raw_element['ELEMENT'] ?? $raw_element[\key($raw_element)]);
+            $elements[] = $this->newElement(
+                isset($raw_element['ELEMENT']) ? $raw_element['ELEMENT'] : $raw_element[\key($raw_element)]
+            );
         }
 
         return $elements;


### PR DESCRIPTION
I was unable to make clicks in selenium + geckodriver, until I made this change.
Mozilla firefox geckodriver fix. ([PHPUnit\Framework\Exception] Undefined index: ELEMENT).