### PR TITLE
Create index.php to include vendor/autoload.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,0 +1,3 @@
+<?php
+//This is required to properly load the library when packaged as a .phar
+include "vendor/autoload.php";


### PR DESCRIPTION
Needed for easy usable phar creation. Default phar will point to 'index.php', instead of what actually loads the correct files ('vendor/autoload.php').