### PR TITLE
added PHPDoc to RemoteWebDriver's execute method

### DIFF
--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -535,6 +535,12 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         return $executor->execute($command)->getValue();
     }
 
+    /**
+     * @param string $command_name
+     * @param array $params
+     * @return mixed|null
+     * @throws \Facebook\WebDriver\Exception\WebDriverException
+     */
     public function execute($command_name, $params = [])
     {
         $command = new WebDriverCommand(


### PR DESCRIPTION
In order to have `@throws WebDriverException`, so IDEs don't complain about unused `catch` statements.