### PR TITLE
added chromedriver (native) instead of selenium proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,28 @@ matrix:
 
     # Add build to run tests against Chrome inside Travis environment
     - php: 7.2
-      env: BROWSER_NAME="chrome" CHROME_HEADLESS="1"
+      env:
+        - BROWSER_NAME="chrome"
+        - CHROME_HEADLESS="1"
+      addons:
+        chrome: stable
+
+    # Add build to run tests against Chrome with Chromedriver inside Travis environment
+    - php: 7.2
+      env:
+        - BROWSER_NAME="chrome"
+        - CHROME_HEADLESS="1"
+        - CHROMEDRIVER="1"
+      addons:
+        chrome: stable
+
+    # Add build to run tests against Chrome with Chromedriver inside Travis environment
+    - php: 7.2
+      env:
+        - BROWSER_NAME="chrome"
+        - CHROME_HEADLESS="1"
+        - CHROMEDRIVER="1"
+        - CHROMEDRIVER_VERSION="latest"
       addons:
         chrome: stable
 
@@ -34,7 +55,10 @@ matrix:
 
     # Chrome on Travis build with lowest possible dependencies
     - php: 7.2
-      env: BROWSER_NAME="chrome" CHROME_HEADLESS="1" DEPENDENCIES="--prefer-lowest"
+      env:
+        - BROWSER_NAME="chrome"
+        - CHROME_HEADLESS="1"
+        - DEPENDENCIES="--prefer-lowest"
       addons:
         chrome: stable
 
@@ -90,11 +114,18 @@ install:
   - travis_retry composer update --no-interaction $DEPENDENCIES
 
 before_script:
-  - if [ "$BROWSER_NAME" = "chrome" ]; then mkdir chromedriver; wget -q -t 3 https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip; unzip chromedriver_linux64 -d chromedriver; fi
+  - if [[ "$BROWSER_NAME" = "chrome" && "$CHROMEDRIVER_VERSION" = "latest" ]]; then CHROMEDRIVER_VERSION=$(curl -sS https://chromedriver.storage.googleapis.com/LATEST_RELEASE); fi
+  - if [ "$BROWSER_NAME" = "chrome" ]; then mkdir chromedriver; wget -q -t 3 "https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip"; unzip chromedriver_linux64 -d chromedriver; fi
   - if [ "$BROWSER_NAME" = "chrome" ]; then export CHROMEDRIVER_PATH=$PWD/chromedriver/chromedriver; fi
   - sh -e /etc/init.d/xvfb start
   - if [ ! -f jar/selenium-server-standalone-3.8.1.jar ]; then wget -q -t 3 -P jar https://selenium-release.storage.googleapis.com/3.8/selenium-server-standalone-3.8.1.jar; fi
-  - java -Dwebdriver.firefox.marionette=false -Dwebdriver.chrome.driver="$CHROMEDRIVER_PATH" -jar jar/selenium-server-standalone-3.8.1.jar -enablePassThrough false -log ./logs/selenium.log &
+  - |
+    if [ "$CHROMEDRIVER" = "1" ]
+    then
+      chromedriver/chromedriver --port=4444 --url-base=wd/hub &> ./logs/chromedriver.log &
+    else
+      java -Dwebdriver.firefox.marionette=false -Dwebdriver.chrome.driver="$CHROMEDRIVER_PATH" -jar jar/selenium-server-standalone-3.8.1.jar -enablePassThrough false -log ./logs/selenium.log &
+    fi
   - until $(echo | nc localhost 4444); do sleep 1; echo Waiting for Selenium server on port 4444...; done; echo "Selenium server started"
   - php -S 127.0.0.1:8000 -t tests/functional/web/ &>>./logs/php-server.log &
   - until $(echo | nc localhost 8000); do sleep 1; echo waiting for PHP server on port 8000...; done; echo "PHP server started"
@@ -107,6 +138,7 @@ script:
 
 after_script:
   - if [ -f ./logs/selenium.log ]; then cat ./logs/selenium.log; fi
+  - if [ -f ./logs/chromedriver.log ]; then cat ./logs/chromedriver.log; fi
   - if [ -f ./logs/php-server.log ]; then cat ./logs/php-server.log; fi
 
 after_success:


### PR DESCRIPTION
[Future of WebDriver](https://sny.no/2015/07/belfast.pdf) presented at Selenium user groups in Belfast and Tel Aviv by @andreastt

> Most vendors will ship a shim that implements  the W3C WebDriver HTTP/JSON-over-TCP wire protocol
> No more drivers maintained by Selenium
> Selenium WebDriver protocol  will be decommissioned

This PR is a small step forward to decommission selenium webdriver in favor of w3c webdriver and to remove drivers that are maintained by Selenium