### PR TITLE
626 no null values in cookie

### DIFF
--- a/lib/Cookie.php
+++ b/lib/Cookie.php
@@ -27,15 +27,7 @@ use InvalidArgumentException;
 class Cookie implements \ArrayAccess
 {
     /** @var array */
-    protected $cookie = [
-        'name' => null,
-        'value' => null,
-        'path' => null,
-        'domain' => null,
-        'expiry' => null,
-        'secure' => null,
-        'httpOnly' => null,
-    ];
+    protected $cookie = [];
 
     /**
      * @param string $name The name of the cookie; may not be null or an empty string.
@@ -51,11 +43,17 @@ class Cookie implements \ArrayAccess
     }
 
     /**
-     * @param array $cookieArray
+     * @param array $cookieArray The cookie fields; must contain name and value.
      * @return Cookie
      */
     public static function createFromArray(array $cookieArray)
     {
+        if (!isset($cookieArray['name'])) {
+            throw new InvalidArgumentException('Cookie name should be set');
+        }
+        if (!isset($cookieArray['value'])) {
+            throw new InvalidArgumentException('Cookie value should be set');
+        }
         $cookie = new self($cookieArray['name'], $cookieArray['value']);
 
         if (isset($cookieArray['path'])) {
@@ -82,7 +80,7 @@ class Cookie implements \ArrayAccess
      */
     public function getName()
     {
-        return $this->cookie['name'];
+        return $this->offsetGet('name');
     }
 
     /**
@@ -90,7 +88,7 @@ class Cookie implements \ArrayAccess
      */
     public function getValue()
     {
-        return $this->cookie['value'];
+        return $this->offsetGet('value');
     }
 
     /**
@@ -100,7 +98,7 @@ class Cookie implements \ArrayAccess
      */
     public function setPath($path)
     {
-        $this->cookie['path'] = $path;
+        $this->offsetSet('path', $path);
     }
 
     /**
@@ -108,7 +106,7 @@ class Cookie implements \ArrayAccess
      */
     public function getPath()
     {
-        return $this->cookie['path'];
+        return $this->offsetGet('path');
     }
 
     /**
@@ -122,7 +120,7 @@ class Cookie implements \ArrayAccess
             throw new InvalidArgumentException(sprintf('Cookie domain "%s" should not contain a port', $domain));
         }
 
-        $this->cookie['domain'] = $domain;
+        $this->offsetSet('domain', $domain);
     }
 
     /**
@@ -130,7 +128,7 @@ class Cookie implements \ArrayAccess
      */
     public function getDomain()
     {
-        return $this->cookie['domain'];
+        return $this->offsetGet('domain');
     }
 
     /**
@@ -140,7 +138,7 @@ class Cookie implements \ArrayAccess
      */
     public function setExpiry($expiry)
     {
-        $this->cookie['expiry'] = (int) $expiry;
+        $this->offsetSet('expiry', (int) $expiry);
     }
 
     /**
@@ -148,7 +146,7 @@ class Cookie implements \ArrayAccess
      */
     public function getExpiry()
     {
-        return $this->cookie['expiry'];
+        return $this->offsetGet('expiry');
     }
 
     /**
@@ -158,7 +156,7 @@ class Cookie implements \ArrayAccess
      */
     public function setSecure($secure)
     {
-        $this->cookie['secure'] = $secure;
+        $this->offsetSet('secure', $secure);
     }
 
     /**
@@ -166,7 +164,7 @@ class Cookie implements \ArrayAccess
      */
     public function isSecure()
     {
-        return $this->cookie['secure'];
+        return $this->offsetGet('secure');
     }
 
     /**
@@ -176,7 +174,7 @@ class Cookie implements \ArrayAccess
      */
     public function setHttpOnly($httpOnly)
     {
-        $this->cookie['httpOnly'] = $httpOnly;
+        $this->offsetSet('httpOnly', $httpOnly);
     }
 
     /**
@@ -184,7 +182,7 @@ class Cookie implements \ArrayAccess
      */
     public function isHttpOnly()
     {
-        return $this->cookie['httpOnly'];
+        return $this->offsetGet('httpOnly');
     }
 
     /**
@@ -202,12 +200,16 @@ class Cookie implements \ArrayAccess
 
     public function offsetGet($offset)
     {
-        return $this->cookie[$offset];
+        return $this->offsetExists($offset) ? $this->cookie[$offset] : null;
     }
 
     public function offsetSet($offset, $value)
     {
-        $this->cookie[$offset] = $value;
+        if ($value === null) {
+            unset($this->cookie[$offset]);
+        } else {
+            $this->cookie[$offset] = $value;
+        }
     }
 
     public function offsetUnset($offset)

--- a/tests/unit/CookieTest.php
+++ b/tests/unit/CookieTest.php
@@ -63,6 +63,28 @@ class CookieTest extends TestCase
     }
 
     /**
+     * Test that there are no null values in the cookie array.
+     *
+     * Both JsonWireProtocol and w3c protocol say to leave an entry off
+     * rather than having a null value.
+     *
+     * https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol
+     * https://w3c.github.io/webdriver/#add-cookie
+     */
+    public function testShouldNotContainNullValues()
+    {
+        $cookie = new Cookie('cookieName', 'someValue');
+
+        $cookie->setHttpOnly(null);
+        $cookie->setPath(null);
+        $cookieArray = $cookie->toArray();
+
+        foreach ($cookieArray as $key => $value) {
+            $this->assertNotNull($value, $key . ' should not be null');
+        }
+    }
+
+    /**
      * @depends testShouldSetAllProperties
      * @param Cookie $cookie
      */


### PR DESCRIPTION
Both JsonWireProtocol and w3c protocol say to leave an entry off
rather than having a null value.

https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol
https://w3c.github.io/webdriver/#add-cookie
