### PR TITLE
Set default timeouts up front instead of overriding them at the end

### DIFF
--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -175,8 +175,6 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         curl_setopt($this->curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($this->curl, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($this->curl, CURLOPT_HTTPHEADER, static::DEFAULT_HTTP_HEADERS);
-        $this->setRequestTimeout(30000);
-        $this->setConnectionTimeout(30000);
     }
 
     /**

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -106,8 +106,15 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         if ($connection_timeout_in_ms !== null) {
             $executor->setConnectionTimeout($connection_timeout_in_ms);
         }
+        else {
+            $executor->setConnectionTimeout(30000);
+        }
+
         if ($request_timeout_in_ms !== null) {
             $executor->setRequestTimeout($request_timeout_in_ms);
+        }
+        else {
+            $executor->setRequestTimeout(30000);
         }
 
         if ($required_capabilities !== null) {


### PR DESCRIPTION
The constructor allows you to set curl timeouts when creating a RemoteWebDriver but then right at execution HttpCommandExecutor always overrides them to be 30 seconds. 
This changes it to set those 30 second defaults only if it wasn't constructed with timeouts.