### PR TITLE
Disable W3C protocol in Chrome 75+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
   global:
     - DISPLAY=:99.0
     - BROWSER_NAME="htmlunit"
-    - CHROMEDRIVER_VERSION="2.38"
 
 matrix:
   include:
@@ -34,15 +33,21 @@ matrix:
     - php: '5.6'
       env: DEPENDENCIES="--prefer-lowest"
 
-    # Add build to run tests against Firefox inside Travis environment
+    # Firefox inside Travis environment
     - php: '7.3'
       env: BROWSER_NAME="firefox"
       addons:
         firefox: "45.8.0esr"
 
-    # Add build to run tests against Chrome inside Travis environment
+    # Stable Chrome + Chromedriver 74 inside Travis environment
     - php: '7.3'
-      env: BROWSER_NAME="chrome" CHROME_HEADLESS="1"
+      env: BROWSER_NAME="chrome" CHROME_HEADLESS="1" CHROMEDRIVER_VERSION="74.0.3729.6"
+      addons:
+        chrome: stable
+
+    # Stable Chrome + Chromedriver 75+ inside Travis environment
+    - php: '7.3'
+      env: BROWSER_NAME="chrome" CHROME_HEADLESS="1" CHROMEDRIVER_VERSION="75.0.3770.8"
       addons:
         chrome: stable
 
@@ -56,8 +61,9 @@ matrix:
         sauce_connect: true
         jwt:
           secure: HPq5xFhosa1eSGnaRdJzeyEuaE0mhRlG1gf3G7+dKS0VniF30husSyrxZhbGCCKBGxmIySoAQzd43BCwL69EkUEVKDN87Cpid1Ce9KrSfU3cnN8XIb+4QINyy7x1a47RUAfaaOEx53TrW0ShalvjD+ZwDE8LrgagSox6KQ+nQLE=
+
     - php: '7.3'
-      env: SAUCELABS=1 BROWSER_NAME="chrome" VERSION="74.0" PLATFORM="Windows 10"
+      env: SAUCELABS=1 BROWSER_NAME="chrome" VERSION="74.0" PLATFORM="Windows 10" # 74 is the last version which don't use W3C WebDriver by default
       before_script:
         - php -S 127.0.0.1:8000 -t tests/functional/web/ &>>./logs/php-server.log &
         - until $(echo | nc localhost 8000); do sleep 1; echo waiting for PHP server on port 8000...; done; echo "PHP server started"
@@ -65,6 +71,17 @@ matrix:
         sauce_connect: true
         jwt:
           secure: HPq5xFhosa1eSGnaRdJzeyEuaE0mhRlG1gf3G7+dKS0VniF30husSyrxZhbGCCKBGxmIySoAQzd43BCwL69EkUEVKDN87Cpid1Ce9KrSfU3cnN8XIb+4QINyy7x1a47RUAfaaOEx53TrW0ShalvjD+ZwDE8LrgagSox6KQ+nQLE=
+
+    - php: '7.3'
+      env: SAUCELABS=1 BROWSER_NAME="chrome" VERSION="75.0" PLATFORM="Windows 10"
+      before_script:
+        - php -S 127.0.0.1:8000 -t tests/functional/web/ &>>./logs/php-server.log &
+        - until $(echo | nc localhost 8000); do sleep 1; echo waiting for PHP server on port 8000...; done; echo "PHP server started"
+      addons:
+        sauce_connect: true
+        jwt:
+          secure: HPq5xFhosa1eSGnaRdJzeyEuaE0mhRlG1gf3G7+dKS0VniF30husSyrxZhbGCCKBGxmIySoAQzd43BCwL69EkUEVKDN87Cpid1Ce9KrSfU3cnN8XIb+4QINyy7x1a47RUAfaaOEx53TrW0ShalvjD+ZwDE8LrgagSox6KQ+nQLE=
+
     - php: '7.3'
       env: SAUCELABS=1 BROWSER_NAME="MicrosoftEdge" VERSION="16.16299" PLATFORM="Windows 10"
       before_script:

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -273,6 +273,11 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
 
         if ($http_method === 'POST' && $params && is_array($params)) {
             $encoded_params = json_encode($params);
+        } elseif ($http_method === 'POST' && $encoded_params === null) {
+            // Workaround for bug https://bugs.chromium.org/p/chromedriver/issues/detail?id=2943 in Chrome 75.
+            // Chromedriver now erroneously does not allow POST body to be empty even for the JsonWire protocol.
+            // If the command POST is empty, here we send some dummy data as a workaround:
+            $encoded_params = json_encode(['_' => '_']);
         }
 
         curl_setopt($this->curl, CURLOPT_POSTFIELDS, $encoded_params);


### PR DESCRIPTION
Chromedriver 75 released together with Chrome 75 on 4th June 2019 uses W3C WebDriver protocol [by default](https://bugs.chromium.org/p/chromedriver/issues/detail?id=2536). 

But php-webdriver does not (see #469) support this protocol yet, so this hotfix disables the W3C WebDriver protocol and re-enables the old one JsonWire aka OSS.

Unfortunately, this change in Chromedriver 75 accidentally broke the old JsonWire protocol, so just disabling the new protocol is not enough :-/. See Chromedriver bug [2943](https://bugs.chromium.org/p/chromedriver/issues/detail?id=2943). The bug causes Chromedriver to require at least some data in POST body request (what should not be required in JsonWire protocol). So as a workaround for the Chromedriver bug, we are adding some dummy data in the body (as [suggested here](https://github.com/nightwatchjs/nightwatch/issues/2118#issuecomment-500020426)), until Chrome team fixes the bug.