### PR TITLE
Fix regression in 1.7.0 - call to a member function toArray() on array

### DIFF
--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -156,6 +156,7 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
+     * @todo Remove side-effects - not change ie. ChromeOptions::CAPABILITY from instance of ChromeOptions to an array
      * @return array
      */
     public function toArray()

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -109,8 +109,10 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
             $currentChromeOptions = $desired_capabilities->getCapability(ChromeOptions::CAPABILITY);
             $chromeOptions = !empty($currentChromeOptions) ? $currentChromeOptions : new ChromeOptions();
 
-            if (!isset($chromeOptions->toArray()['w3c'])) {
+            if ($chromeOptions instanceof ChromeOptions && !isset($chromeOptions->toArray()['w3c'])) {
                 $chromeOptions->setExperimentalOption('w3c', false);
+            } elseif (is_array($chromeOptions) && !isset($chromeOptions['w3c'])) {
+                $chromeOptions['w3c'] = false;
             }
 
             $desired_capabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);

--- a/tests/functional/RemoteWebDriverCreateTest.php
+++ b/tests/functional/RemoteWebDriverCreateTest.php
@@ -49,6 +49,19 @@ class RemoteWebDriverCreateTest extends WebDriverTestCase
         $this->assertSame($this->desiredCapabilities->getBrowserName(), $returnedCapabilities->getBrowserName());
     }
 
+    public function testShouldAcceprCapabilitiesAsAnArray()
+    {
+        // Method has a side-effect of converting whole content of desiredCapabilities to an array
+        $this->desiredCapabilities->toArray();
+
+        $this->driver = RemoteWebDriver::create(
+            $this->serverUrl,
+            $this->desiredCapabilities,
+            $this->connectionTimeout,
+            $this->requestTimeout
+        );
+    }
+
     public function testShouldCreateWebDriverWithRequiredCapabilities()
     {
         $requiredCapabilities = new DesiredCapabilities();


### PR DESCRIPTION
Close #642 

DesiredCapabilities#toArray() is a mutable operation which can lead to undesirable side effect. Cloning the instance before calling it will prevent this.

Exemple of side effect : 
```php
<?php

use Facebook\WebDriver\Chrome\ChromeOptions;
use Facebook\WebDriver\Remote\DesiredCapabilities;

require __DIR__.'/vendor/autoload.php';

$capabilities = new DesiredCapabilities();
$capabilities->setCapability(ChromeOptions::CAPABILITY, new ChromeOptions());
$options = $capabilities->getCapability(ChromeOptions::CAPABILITY); // Instance of Facebook\WebDriver\Chrome\ChromeOptions
$capabilities->toArray();
$options = $capabilities->getCapability(ChromeOptions::CAPABILITY); // Oh no it's an array
```