### PR TITLE
Do not send w3c capability as a workaround for browsestack schema validation

### DIFF
--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -105,7 +105,9 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
 
         // Hotfix: W3C WebDriver protocol is not yet supported by php-webdriver, so we must force Chromedriver to
         // not use the W3C protocol by default (which is what Chromedriver does starting with version 75).
-        if ($desired_capabilities->getBrowserName() === WebDriverBrowserType::CHROME) {
+        if ($desired_capabilities->getBrowserName() === WebDriverBrowserType::CHROME
+            && mb_strpos($selenium_server_url, 'browserstack') === false // see https://github.com/facebook/php-webdriver/issues/644
+        ) {
             $currentChromeOptions = $desired_capabilities->getCapability(ChromeOptions::CAPABILITY);
             $chromeOptions = !empty($currentChromeOptions) ? $currentChromeOptions : new ChromeOptions();
 


### PR DESCRIPTION
Ref #644 