### PR TITLE
add missing json wire protocol for status command

### DIFF
--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -126,6 +126,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
             'method' => 'POST',
             'url' => '/session/:sessionId/window/:windowHandle/size',
         ],
+        DriverCommand::STATUS => ['method' => 'GET', 'url' => '/status'],
         DriverCommand::SUBMIT_ELEMENT => ['method' => 'POST', 'url' => '/session/:sessionId/element/:id/submit'],
         DriverCommand::SCREENSHOT => ['method' => 'GET', 'url' => '/session/:sessionId/screenshot'],
         DriverCommand::TOUCH_SINGLE_TAP => ['method' => 'POST', 'url' => '/session/:sessionId/touch/click'],


### PR DESCRIPTION
'status' is defined in the DriverCommand class but it's not usable unless the wire protocol is defined in HttpCommandExecutor.