### PR TITLE
updating to latest chromeWebdriver options structure

### DIFF
--- a/lib/Chrome/ChromeOptions.php
+++ b/lib/Chrome/ChromeOptions.php
@@ -27,7 +27,7 @@ class ChromeOptions
     /**
      * The key of chrome options in desired capabilities.
      */
-    const CAPABILITY = 'chromeOptions';
+    const CAPABILITY = 'goog:chromeOptions';
     /**
      * @var array
      */


### PR DESCRIPTION
Chrome WebDriver has changed the chrome options lately which leaves this repo a broken dependency to all other modules using this as a base.
`CAPABILITY` should 'goog:chromeOptions' instead of 'chromeOptions'