### PR TITLE
Fixing Chrome 77

### DIFF
--- a/lib/remote/RemoteWebDriver.php
+++ b/lib/remote/RemoteWebDriver.php
@@ -133,7 +133,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor {
       $params
     );
 
-    return $this->newElement($raw_element['ELEMENT']);
+    return $this->newElement($raw_element[key($raw_element)]);
   }
 
   /**
@@ -154,7 +154,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor {
 
     $elements = array();
     foreach ($raw_elements as $raw_element) {
-      $elements[] = $this->newElement($raw_element['ELEMENT']);
+      $elements[] = $this->newElement($raw_element[key($raw_element)]);
     }
     return $elements;
   }

--- a/lib/remote/RemoteWebDriver.php
+++ b/lib/remote/RemoteWebDriver.php
@@ -133,7 +133,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor {
       $params
     );
 
-    return $this->newElement($raw_element[key($raw_element)]);
+    return $this->newElement(current($raw_element));
   }
 
   /**
@@ -154,7 +154,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor {
 
     $elements = array();
     foreach ($raw_elements as $raw_element) {
-      $elements[] = $this->newElement($raw_element[key($raw_element)]);
+      $elements[] = $this->newElement(current($raw_element));
     }
     return $elements;
   }

--- a/lib/remote/RemoteWebElement.php
+++ b/lib/remote/RemoteWebElement.php
@@ -88,7 +88,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable {
       $params
     );
 
-    return $this->newElement($raw_element['ELEMENT']);
+    return $this->newElement($raw_element[key($raw_element)]);
   }
 
   /**
@@ -112,7 +112,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable {
 
     $elements = array();
     foreach ($raw_elements as $raw_element) {
-      $elements[] = $this->newElement($raw_element['ELEMENT']);
+      $elements[] = $this->newElement(key($raw_element));
     }
     return $elements;
   }

--- a/lib/remote/RemoteWebElement.php
+++ b/lib/remote/RemoteWebElement.php
@@ -88,7 +88,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable {
       $params
     );
 
-    return $this->newElement($raw_element[key($raw_element)]);
+    return $this->newElement(current($raw_element));
   }
 
   /**
@@ -112,7 +112,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable {
 
     $elements = array();
     foreach ($raw_elements as $raw_element) {
-      $elements[] = $this->newElement(key($raw_element));
+      $elements[] = $this->newElement(current($raw_element));
     }
     return $elements;
   }


### PR DESCRIPTION
Find element array labels are now dynamic, causing crashes on chrome 77

Undefined index: ELEMENT