### PR TITLE
Compatibility with Symfony 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Revert no longer needed workaround for Chromedriver bug [2943](https://bugs.chromium.org/p/chromedriver/issues/detail?id=2943).
+- Allow installation of Symfony 5 components.
 
 ## 1.7.1 - 2019-06-13
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "minimum-stability": "beta",
   "require": {
     "php": "^5.6 || ~7.0",
-    "symfony/process": "^2.8 || ^3.1 || ^4.0",
+    "symfony/process": "^2.8 || ^3.1 || ^4.0 || ^5.0",
     "ext-curl": "*",
     "ext-zip": "*",
     "ext-mbstring": "*",
@@ -26,7 +26,7 @@
     "squizlabs/php_codesniffer": "^2.6",
     "php-mock/php-mock-phpunit": "^1.1",
     "php-coveralls/php-coveralls": "^2.0",
-    "symfony/var-dumper": "^3.3 || ^4.0",
+    "symfony/var-dumper": "^3.3 || ^4.0 || ^5.0",
     "jakub-onderka/php-parallel-lint": "^0.9.2"
   },
   "suggest": {


### PR DESCRIPTION
Symfony 5 is about to be released, this PR allows to use PHP WebDriver (and so Panther) with it. There is no code changes, the new version only has to be allowed in `composer.json`.

@OndraM could you tag a new release after merging please 🙏?