### PR TITLE
Revert chromedriver workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
 
     # Stable Chrome + Chromedriver 75+ inside Travis environment
     - php: '7.3'
-      env: BROWSER_NAME="chrome" CHROME_HEADLESS="1" CHROMEDRIVER_VERSION="75.0.3770.8"
+      env: BROWSER_NAME="chrome" CHROME_HEADLESS="1" CHROMEDRIVER_VERSION="75.0.3770.90"
       addons:
         chrome: stable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,15 +39,9 @@ matrix:
       addons:
         firefox: "45.8.0esr"
 
-    # Stable Chrome + Chromedriver 74 inside Travis environment
+    # Stable Chrome + Chromedriver inside Travis environment
     - php: '7.3'
-      env: BROWSER_NAME="chrome" CHROME_HEADLESS="1" CHROMEDRIVER_VERSION="74.0.3729.6"
-      addons:
-        chrome: stable
-
-    # Stable Chrome + Chromedriver 75+ inside Travis environment
-    - php: '7.3'
-      env: BROWSER_NAME="chrome" CHROME_HEADLESS="1" CHROMEDRIVER_VERSION="75.0.3770.90"
+      env: BROWSER_NAME="chrome" CHROME_HEADLESS="1"
       addons:
         chrome: stable
 
@@ -102,7 +96,7 @@ install:
   - travis_retry composer update --no-interaction $DEPENDENCIES
 
 before_script:
-  - if [ "$BROWSER_NAME" = "chrome" ]; then mkdir chromedriver; wget -q -t 3 https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip; unzip chromedriver_linux64 -d chromedriver; fi
+  - if [ "$BROWSER_NAME" = "chrome" ]; then mkdir chromedriver; CHROMEDRIVER_VERSION=$(wget -qO- "https://chromedriver.storage.googleapis.com/LATEST_RELEASE"); wget -q -t 3 https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip; unzip chromedriver_linux64 -d chromedriver; fi
   - if [ "$BROWSER_NAME" = "chrome" ]; then export CHROMEDRIVER_PATH=$PWD/chromedriver/chromedriver; fi
   - sh -e /etc/init.d/xvfb start
   - if [ ! -f jar/selenium-server-standalone-3.8.1.jar ]; then wget -q -t 3 -P jar https://selenium-release.storage.googleapis.com/3.8/selenium-server-standalone-3.8.1.jar; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+- Revert no longer needed workaround for Chromedriver bug [2943](https://bugs.chromium.org/p/chromedriver/issues/detail?id=2943).
+
 ## 1.7.1 - 2019-06-13
 ### Fixed
 - Error `Call to a member function toArray()` if capabilities were already converted to an array.

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -273,11 +273,6 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
 
         if ($http_method === 'POST' && $params && is_array($params)) {
             $encoded_params = json_encode($params);
-        } elseif ($http_method === 'POST' && $encoded_params === null) {
-            // Workaround for bug https://bugs.chromium.org/p/chromedriver/issues/detail?id=2943 in Chrome 75.
-            // Chromedriver now erroneously does not allow POST body to be empty even for the JsonWire protocol.
-            // If the command POST is empty, here we send some dummy data as a workaround:
-            $encoded_params = json_encode(['_' => '_']);
         }
 
         curl_setopt($this->curl, CURLOPT_POSTFIELDS, $encoded_params);


### PR DESCRIPTION
Reverts #644 & #645, because workaround is no longer needed since chrome 75.0.3770.90.

Also make chrome tests on Travis use automatically the latest chromedriver binary.