### PR TITLE
Make chromeOptions compatible with both JsonWire and W3C protocols

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   global:
     - DISPLAY=:99.0
     - BROWSER_NAME="htmlunit"
+    - SELENIUM_SERVER="https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar" # Latest version including HtmlUnit
 
 matrix:
   include:
@@ -36,9 +37,11 @@ matrix:
       env: DEPENDENCIES="--prefer-lowest"
 
     # Firefox inside Travis environment
-    - name: 'Firefox 45 on Travis (OSS protocol); via Selenium server'
+    - name: 'Firefox 45 on Travis (OSS protocol); via legacy Selenium server'
       php: '7.3'
-      env: BROWSER_NAME="firefox"
+      env:
+        - BROWSER_NAME="firefox"
+        - SELENIUM_SERVER="legacy"
       addons:
         firefox: "45.8.0esr"
 
@@ -114,7 +117,6 @@ matrix:
 cache:
   directories:
     - $HOME/.composer/cache
-    - jar
 
 install:
   - travis_retry composer self-update
@@ -123,15 +125,24 @@ install:
 before_script:
   - if [ "$BROWSER_NAME" = "chrome" ]; then mkdir chromedriver; CHROMEDRIVER_VERSION=$(wget -qO- "https://chromedriver.storage.googleapis.com/LATEST_RELEASE"); wget -q -t 3 https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip; unzip chromedriver_linux64 -d chromedriver; fi
   - if [ "$BROWSER_NAME" = "chrome" ]; then export CHROMEDRIVER_PATH=$PWD/chromedriver/chromedriver; fi
-  - if [ "$GECKODRIVER" = "1" ]; then mkdir geckodriver; wget -q -t 3 https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz; tar xzf geckodriver-v0.26.0-linux64.tar.gz -C geckodriver; fi
-  - sh -e /etc/init.d/xvfb start
-  - if [ ! -f jar/selenium-server-standalone-3.8.1.jar ]; then wget -q -t 3 -P jar https://selenium-release.storage.googleapis.com/3.8/selenium-server-standalone-3.8.1.jar; fi
+  - if [ "$GECKODRIVER" = "1" ]; then mkdir -p geckodriver; wget -q -t 3 https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz; tar xzf geckodriver-v0.26.0-linux64.tar.gz -C geckodriver; fi
+  - sh -e /etc/init.d/xvfb start # TODO: start only when needed (ie. not in headless mode)
+  - if [ ! -f jar/selenium-server-standalone.jar ] && [ -n "$SELENIUM_SERVER" ]; then
+      mkdir -p jar;
+      if [ "$SELENIUM_SERVER" = "legacy" ]; then
+        wget -q -t 3 -O jar/selenium-server-standalone.jar https://selenium-release.storage.googleapis.com/3.8/selenium-server-standalone-3.8.1.jar;
+      else
+        wget -q -t 3 -O jar/selenium-server-standalone.jar $SELENIUM_SERVER;
+      fi
+    fi
   - if [ "$GECKODRIVER" = "1" ]; then
       geckodriver/geckodriver &> ./logs/geckodriver.log &
     elif [ "$CHROMEDRIVER" = "1" ]; then
       chromedriver/chromedriver --port=4444 --url-base=/wd/hub &> ./logs/chromedriver.log &
+    elif [ "$SELENIUM_SERVER" = "legacy" ]; then
+      java -Dwebdriver.firefox.marionette=false -Dwebdriver.chrome.driver="$PWD/chromedriver/chromedriver" -jar jar/selenium-server-standalone.jar -enablePassThrough false -log ./logs/selenium.log &
     else
-      java -Dwebdriver.firefox.marionette=false -Dwebdriver.chrome.driver="$CHROMEDRIVER_PATH" -jar jar/selenium-server-standalone-3.8.1.jar -enablePassThrough false -log ./logs/selenium.log &
+      java -Dwebdriver.chrome.driver="$PWD/chromedriver/chromedriver" -Dwebdriver.gecko.driver="$PWD/geckodriver/geckodriver" -jar jar/selenium-server-standalone.jar -log ./logs/selenium.log &
     fi
   - until $(echo | nc localhost 4444); do sleep 1; echo Waiting for Selenium server on port 4444...; done; echo "Selenium server started"
   - php -S 127.0.0.1:8000 -t tests/functional/web/ &>>./logs/php-server.log &

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ env:
 matrix:
   include:
     # Codestyle check build
-    - php: '7.3'
+    - name: 'Code style and static analysis'
+      php: '7.3'
       env: CHECK_CODESTYLE=1
       before_install:
         - phpenv config-rm xdebug.ini
@@ -30,18 +31,19 @@ matrix:
       after_success: ~
 
     # Build with lowest possible dependencies on lowest possible PHP
-    - php: '5.6'
+    - name: 'Lowest dependencies build'
+      php: '5.6'
       env: DEPENDENCIES="--prefer-lowest"
 
     # Firefox inside Travis environment
-    - name: 'Firefox 45 on Travis (OSS protocol)'
+    - name: 'Firefox 45 on Travis (OSS protocol); via Selenium server'
       php: '7.3'
       env: BROWSER_NAME="firefox"
       addons:
         firefox: "45.8.0esr"
 
     # Firefox with Geckodriver (W3C mode) inside Travis environment
-    - name: 'Firefox latest on Travis (W3C protocol)'
+    - name: 'Firefox latest on Travis (W3C protocol); no Selenium server'
       php: 7.3
       env:
         - BROWSER_NAME="firefox"
@@ -49,9 +51,22 @@ matrix:
       addons:
         firefox: latest
 
-    # Stable Chrome + Chromedriver inside Travis environment
-    - php: '7.3'
-      env: BROWSER_NAME="chrome" CHROME_HEADLESS="1"
+    # Stable Chrome + Chromedriver inside Travis environment via Selenium server proxy
+    - name: 'Chrome stable on Travis; via Selenium server'
+      php: '7.3'
+      env:
+        - BROWSER_NAME="chrome"
+        - CHROME_HEADLESS="1"
+      addons:
+        chrome: stable
+
+    # Stable Chrome + Chromedriver inside Travis environment directly via Chromedriver
+    - name: 'Chrome stable on Travis; no Selenium server'
+      php: '7.3'
+      env:
+        - BROWSER_NAME="chrome"
+        - CHROME_HEADLESS="1"
+        - CHROMEDRIVER="1"
       addons:
         chrome: stable
 
@@ -113,6 +128,8 @@ before_script:
   - if [ ! -f jar/selenium-server-standalone-3.8.1.jar ]; then wget -q -t 3 -P jar https://selenium-release.storage.googleapis.com/3.8/selenium-server-standalone-3.8.1.jar; fi
   - if [ "$GECKODRIVER" = "1" ]; then
       geckodriver/geckodriver &> ./logs/geckodriver.log &
+    elif [ "$CHROMEDRIVER" = "1" ]; then
+      chromedriver/chromedriver --port=4444 --url-base=/wd/hub &> ./logs/chromedriver.log &
     else
       java -Dwebdriver.firefox.marionette=false -Dwebdriver.chrome.driver="$CHROMEDRIVER_PATH" -jar jar/selenium-server-standalone-3.8.1.jar -enablePassThrough false -log ./logs/selenium.log &
     fi
@@ -130,6 +147,7 @@ after_script:
   - if [ -f ./logs/selenium.log ]; then cat ./logs/selenium.log; fi
   - if [ -f ./logs/php-server.log ]; then cat ./logs/php-server.log; fi
   - if [ -f ./logs/geckodriver.log ]; then cat ./logs/geckodriver.log; fi
+  - if [ -f ./logs/chromedriver.log ]; then cat ./logs/chromedriver.log; fi
 
 after_success:
   - travis_retry php vendor/bin/php-coveralls -v

--- a/lib/Chrome/ChromeOptions.php
+++ b/lib/Chrome/ChromeOptions.php
@@ -25,9 +25,14 @@ use Facebook\WebDriver\Remote\DesiredCapabilities;
 class ChromeOptions
 {
     /**
-     * The key of chrome options in desired capabilities.
+     * The key of chrome options desired capabilities (in legacy OSS JsonWire protocol)
+     * @deprecated
      */
     const CAPABILITY = 'chromeOptions';
+    /**
+     * The key of chrome options desired capabilities (in W3C compatible protocol)
+     */
+    const CAPABILITY_W3C = 'goog:chromeOptions';
     /**
      * @var array
      */

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -140,15 +140,15 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         // W3C
         $parameters = [
             'capabilities' => [
-                'firstMatch' => [$desired_capabilities->toArray()],
+                'firstMatch' => [static::convertCapabilitiesToW3c($desired_capabilities->toArray())],
             ],
         ];
 
-        // Legacy protocol
-        if (null !== $required_capabilities && $required_capabilities_array = $required_capabilities->toArray()) {
-            $parameters['capabilities']['alwaysMatch'] = $required_capabilities_array;
+        if ($required_capabilities !== null && $required_capabilities_array = $required_capabilities->toArray()) {
+            $parameters['capabilities']['alwaysMatch'] = static::convertCapabilitiesToW3c($required_capabilities_array);
         }
 
+        // Legacy protocol
         if ($required_capabilities !== null) {
             // TODO: Selenium (as of v3.0.1) does accept requiredCapabilities only as a property of desiredCapabilities.
             // This has changed with the W3C WebDriver spec, but is the only way how to pass these
@@ -676,5 +676,29 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         }
 
         return $desired_capabilities;
+    }
+
+    /**
+     * Convert keys invalid in W3C capabilities to corresponding ones for W3C.
+     *
+     * @param array $capabilitiesArray
+     * @return array
+     */
+    protected static function convertCapabilitiesToW3c(array $capabilitiesArray)
+    {
+        if (array_key_exists(ChromeOptions::CAPABILITY, $capabilitiesArray)) {
+            if (array_key_exists(ChromeOptions::CAPABILITY_W3C, $capabilitiesArray)) {
+                $capabilitiesArray[ChromeOptions::CAPABILITY_W3C] = array_merge(
+                    $capabilitiesArray[ChromeOptions::CAPABILITY],
+                    $capabilitiesArray[ChromeOptions::CAPABILITY_W3C]
+                );
+            } else {
+                $capabilitiesArray[ChromeOptions::CAPABILITY_W3C] = $capabilitiesArray[ChromeOptions::CAPABILITY];
+            }
+
+            unset($capabilitiesArray[ChromeOptions::CAPABILITY]);
+        }
+
+        return $capabilitiesArray;
     }
 }


### PR DESCRIPTION
This workaround resolves issue which emerged after #560 .

Newer Selenium servers reject `chromeOptions` key in capabilities, because it does not contain vendor prefix, what is required as per W3C protocol. However simply updating the prefix would break on the other hand older Chromedrivers - and we want to maintain BC with version 1 of this library.

Ref. #652 #551 #573 #469 