### PR TITLE
Enable W3C protocol for Chrome 🎉

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,8 @@ matrix:
       addons:
         firefox: latest
 
-    # Stable Chrome + Chromedriver inside Travis environment via Selenium server proxy
-    - name: 'Chrome stable on Travis; via Selenium server'
+    # Stable Chrome + Chromedriver (W3C mode) inside Travis environment via Selenium server proxy
+    - name: 'Chrome stable on Travis (W3C protocol); via Selenium server'
       php: '7.3'
       env:
         - BROWSER_NAME="chrome"
@@ -63,13 +63,24 @@ matrix:
       addons:
         chrome: stable
 
-    # Stable Chrome + Chromedriver inside Travis environment directly via Chromedriver
-    - name: 'Chrome stable on Travis; no Selenium server'
+    # Stable Chrome + Chromedriver (W3C mode) inside Travis environment directly via Chromedriver
+    - name: 'Chrome stable on Travis (W3C protocol); no Selenium server'
       php: '7.3'
       env:
         - BROWSER_NAME="chrome"
         - CHROME_HEADLESS="1"
         - CHROMEDRIVER="1"
+      addons:
+        chrome: stable
+
+    # Stable Chrome + Chromedriver (JsonWire OSS mode) inside Travis environment directly via Chromedriver
+    - name: 'Chrome stable on Travis (OSS protocol); no Selenium server'
+      php: '7.3'
+      env:
+        - BROWSER_NAME="chrome"
+        - CHROME_HEADLESS="1"
+        - CHROMEDRIVER="1"
+        - DISABLE_W3C_PROTOCOL="1"
       addons:
         chrome: stable
 

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -112,23 +112,6 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
 
         $desired_capabilities = self::castToDesiredCapabilitiesObject($desired_capabilities);
 
-        // Hotfix: W3C WebDriver protocol is not yet supported by php-webdriver, so we must force Chromedriver to
-        // not use the W3C protocol by default (which is what Chromedriver does starting with version 75).
-        if ($desired_capabilities->getBrowserName() === WebDriverBrowserType::CHROME
-            && mb_strpos($selenium_server_url, 'browserstack') === false // see https://github.com/facebook/php-webdriver/issues/644
-        ) {
-            $currentChromeOptions = $desired_capabilities->getCapability(ChromeOptions::CAPABILITY);
-            $chromeOptions = !empty($currentChromeOptions) ? $currentChromeOptions : new ChromeOptions();
-
-            if ($chromeOptions instanceof ChromeOptions && !isset($chromeOptions->toArray()['w3c'])) {
-                $chromeOptions->setExperimentalOption('w3c', false);
-            } elseif (is_array($chromeOptions) && !isset($chromeOptions['w3c'])) {
-                $chromeOptions['w3c'] = false;
-            }
-
-            $desired_capabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);
-        }
-
         $executor = new HttpCommandExecutor($selenium_server_url, $http_proxy, $http_proxy_port);
         if ($connection_timeout_in_ms !== null) {
             $executor->setConnectionTimeout($connection_timeout_in_ms);

--- a/tests/functional/RemoteWebDriverFindElementTest.php
+++ b/tests/functional/RemoteWebDriverFindElementTest.php
@@ -67,11 +67,9 @@ class RemoteWebDriverFindElementTest extends WebDriverTestCase
      */
     public function testEscapeCssSelector()
     {
-        if (getenv('GECKODRIVER') !== '1') {
-            $this->markTestSkipped(
-                'CSS selectors containing special characters are not supported by the legacy protocol'
-            );
-        }
+        self::skipForJsonWireProtocol(
+            'CSS selectors containing special characters are not supported by the legacy protocol'
+        );
 
         $this->driver->get($this->getTestPageUrl('escape_css.html'));
 

--- a/tests/functional/RemoteWebDriverTest.php
+++ b/tests/functional/RemoteWebDriverTest.php
@@ -150,7 +150,6 @@ class RemoteWebDriverTest extends WebDriverTestCase
         $this->driver->get($this->getTestPageUrl('open_new_window.html'));
         $this->driver->findElement(WebDriverBy::cssSelector('a'))->click();
 
-        // Mandatory for Geckodriver
         $this->driver->wait()->until(WebDriverExpectedCondition::numberOfWindowsToBe(2));
 
         $this->assertCount(2, $this->driver->getWindowHandles());

--- a/tests/functional/RemoteWebElementTest.php
+++ b/tests/functional/RemoteWebElementTest.php
@@ -272,9 +272,7 @@ class RemoteWebElementTest extends WebDriverTestCase
      */
     public function testShouldCompareEqualsElement()
     {
-        if (getenv('GECKODRIVER') === '1') {
-            $this->markTestSkipped('"equals" is not supported by the W3C specification');
-        }
+        self::skipForW3cProtocol('"equals" is not supported by the W3C specification');
 
         $this->driver->get($this->getTestPageUrl('index.html'));
 

--- a/tests/functional/WebDriverActionsTest.php
+++ b/tests/functional/WebDriverActionsTest.php
@@ -49,7 +49,7 @@ class WebDriverActionsTest extends WebDriverTestCase
         $logs = ['mouseover item-1', 'mousedown item-1', 'mouseup item-1', 'click item-1'];
         $loggedEvents = $this->retrieveLoggedEvents();
 
-        if ('1' === getenv('GECKODRIVER')) {
+        if (getenv('GECKODRIVER') === '1') {
             $loggedEvents = array_slice($loggedEvents, 0, count($logs));
             // Firefox sometimes triggers some extra events
             // it's not related to Geckodriver, it's Firefox's own behavior
@@ -77,7 +77,7 @@ class WebDriverActionsTest extends WebDriverTestCase
             ->release()
             ->perform();
 
-        if ('1' === getenv('GECKODRIVER')) {
+        if (self::isW3cProtocolBuild()) {
             $this->assertArraySubset(['mouseover item-1', 'mousedown item-1'], $this->retrieveLoggedEvents());
         } else {
             $this->assertSame(

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -57,6 +57,11 @@ class WebDriverTestCase extends TestCase
                 $chromeOptions = new ChromeOptions();
                 // --no-sandbox is a workaround for Chrome crashing: https://github.com/SeleniumHQ/selenium/issues/4961
                 $chromeOptions->addArguments(['--headless', 'window-size=1024,768', '--no-sandbox']);
+
+                if (getenv('DISABLE_W3C_PROTOCOL')) {
+                    $chromeOptions->setExperimentalOption('w3c', false);
+                }
+
                 $this->desiredCapabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);
             } elseif (getenv('GECKODRIVER') === '1') {
                 $this->serverUrl = 'http://localhost:4444';

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -103,6 +103,32 @@ class WebDriverTestCase extends TestCase
     }
 
     /**
+     * @return bool
+     */
+    public static function isW3cProtocolBuild()
+    {
+        return getenv('GECKODRIVER') === '1'
+            || (getenv('BROWSER_NAME') === 'chrome'
+                && getenv('DISABLE_W3C_PROTOCOL') !== '1'
+                && !self::isSauceLabsBuild());
+    }
+
+    public static function skipForW3cProtocol($message = 'Not supported by W3C specification')
+    {
+        if (static::isW3cProtocolBuild()) {
+            static::markTestSkipped($message);
+        }
+    }
+
+    public static function skipForJsonWireProtocol($message = 'Not supported by JsonWire protocol')
+    {
+        if (getenv('GECKODRIVER') !== '1'
+            && (getenv('CHROMEDRIVER') !== '1' || getenv('DISABLE_W3C_PROTOCOL') === '1')) {
+            static::markTestSkipped($message);
+        }
+    }
+
+    /**
      * Get the URL of given test HTML on running webserver.
      *
      * @param string $path


### PR DESCRIPTION
W3C protocol was forced to be disabled when using Chrome (#640).

But now we can remove this and let the handshake added in #560 to determine the proper protocol to use. So starting to next release of php-webdriver (1.8.0), W3C protocol will be used be default when used with Chromedriver 75+ (and also with Firefox+Geckodriver). 

In case of troubles this could be still disabled using capabilities (as we do in on travis build):

```php
$chromeOptions = new ChromeOptions();
$chromeOptions->setExperimentalOption('w3c', false);

$capabilities = DesiredCapabilities::chrome();
$capabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);

$driver = RemoteWebDriver::create($hostUrl, $capabilities);
```