### PR TITLE
Make ActiveElement endpoint W3C compatible

### DIFF
--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -146,6 +146,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         DriverCommand::DISMISS_ALERT => ['method' => 'POST', 'url' => '/session/:sessionId/alert/dismiss'],
         DriverCommand::EXECUTE_ASYNC_SCRIPT => ['method' => 'POST', 'url' => '/session/:sessionId/execute/async'],
         DriverCommand::EXECUTE_SCRIPT => ['method' => 'POST', 'url' => '/session/:sessionId/execute/sync'],
+        DriverCommand::GET_ACTIVE_ELEMENT => ['method' => 'GET', 'url' => '/session/:sessionId/element/active'],
         DriverCommand::GET_ALERT_TEXT => ['method' => 'GET', 'url' => '/session/:sessionId/alert/text'],
         DriverCommand::GET_CURRENT_WINDOW_HANDLE => ['method' => 'GET', 'url' => '/session/:sessionId/window'],
         DriverCommand::GET_ELEMENT_LOCATION => ['method' => 'GET', 'url' => '/session/:sessionId/element/:id/rect'],

--- a/tests/functional/RemoteTargetLocatorTest.php
+++ b/tests/functional/RemoteTargetLocatorTest.php
@@ -15,6 +15,8 @@
 
 namespace Facebook\WebDriver;
 
+use Facebook\WebDriver\Remote\RemoteWebElement;
+
 /**
  * @covers \Facebook\WebDriver\Remote\RemoteTargetLocator
  */
@@ -51,5 +53,22 @@ class RemoteTargetLocatorTest extends WebDriverTestCase
         // After switchTo() is called, the active window should be changed
         $this->assertContains('index.html', $this->driver->getCurrentURL());
         $this->assertNotSame($originalWindowHandle, $this->driver->getWindowHandle());
+    }
+
+    /**
+     * @cover ::activeElement
+     */
+    public function testActiveElement()
+    {
+        $this->driver->get($this->getTestPageUrl('index.html'));
+
+        $activeElement = $this->driver->switchTo()->activeElement();
+        $this->assertInstanceOf(RemoteWebElement::class, $activeElement);
+        $this->assertSame('body', $activeElement->getTagName());
+
+        $this->driver->findElement(WebDriverBy::name('test_name'))->click();
+        $activeElement = $this->driver->switchTo()->activeElement();
+        $this->assertSame('input', $activeElement->getTagName());
+        $this->assertSame('test_name', $activeElement->getAttribute('name'));
     }
 }


### PR DESCRIPTION
As defined in the specification 12.2.6:

HTTP Method   URI Template
GET           /session/{session id}/element/active

Source: https://www.w3.org/TR/webdriver/#get-active-element