### PR TITLE
Frame switching W3C Compliance

### DIFF
--- a/lib/Remote/RemoteTargetLocator.php
+++ b/lib/Remote/RemoteTargetLocator.php
@@ -62,16 +62,39 @@ class RemoteTargetLocator implements WebDriverTargetLocator
     /**
      * Switch to the iframe by its id or name.
      *
-     * @param WebDriverElement|string $frame The WebDriverElement,
+     * @param WebDriverElement|null|int|string $frame The WebDriverElement,
      * the id or the name of the frame.
+     * When null, switch to the current top-level browsing context
+     * When int, switch to the WindowProxy identified by the value
+     * When an Element, switch to that Element.
+     *
+     * @throws \InvalidArgumentException
      * @return WebDriver The driver focused on the given frame.
      */
     public function frame($frame)
     {
-        if ($frame instanceof WebDriverElement) {
-            $id = ['ELEMENT' => $frame->getID()];
+        if ($this->isW3cCompliant) {
+            if ($frame instanceof WebDriverElement) {
+                $id = [JsonWireCompat::WEB_DRIVER_ELEMENT_IDENTIFIER => $frame->getID()];
+            } elseif ($frame === null) {
+                $id = null;
+            } elseif (is_int($frame)) {
+                $id = $frame;
+            } else {
+                throw new \InvalidArgumentException(
+                    'In W3C compliance mode frame must be either instance of WebDriverElement, integer or null'
+                );
+            }
         } else {
-            $id = (string) $frame;
+            if ($frame instanceof WebDriverElement) {
+                $id = ['ELEMENT' => $frame->getID()];
+            } elseif ($frame === null) {
+                $id = null;
+            } elseif (is_int($frame)) {
+                $id = $frame;
+            } else {
+                $id = (string) $frame;
+            }
         }
 
         $params = ['id' => $id];

--- a/tests/functional/RemoteTargetLocatorTest.php
+++ b/tests/functional/RemoteTargetLocatorTest.php
@@ -71,4 +71,76 @@ class RemoteTargetLocatorTest extends WebDriverTestCase
         $this->assertSame('input', $activeElement->getTagName());
         $this->assertSame('test_name', $activeElement->getAttribute('name'));
     }
+
+    /**
+     * @cover ::frame
+     */
+    public function testShouldSwitchToFrameByItsId()
+    {
+        $parentPage = 'This is the host page which contains an iFrame';
+        $firstChildFrame = 'This is the content of the iFrame';
+        $secondChildFrame = 'open new window';
+
+        $this->driver->get($this->getTestPageUrl('page_with_frame.html'));
+
+        $this->assertContains($parentPage, $this->driver->getPageSource());
+
+        $this->driver->switchTo()->frame(0);
+        $this->assertContains($firstChildFrame, $this->driver->getPageSource());
+
+        $this->driver->switchTo()->frame(null);
+        $this->assertContains($parentPage, $this->driver->getPageSource());
+
+        $this->driver->switchTo()->frame(1);
+        $this->assertContains($secondChildFrame, $this->driver->getPageSource());
+
+        $this->driver->switchTo()->frame(null);
+        $this->assertContains($parentPage, $this->driver->getPageSource());
+    }
+
+    /**
+     * @cover ::frame
+     */
+    public function testShouldSwitchToFrameByElement()
+    {
+        $this->driver->get($this->getTestPageUrl('page_with_frame.html'));
+
+        $element = $this->driver->findElement(WebDriverBy::id('iframe_content'));
+        $this->driver->switchTo()->frame($element);
+
+        $this->assertContains('This is the content of the iFrame', $this->driver->getPageSource());
+    }
+
+    /**
+     * @cover ::frame
+     * @group exclude-saucelabs
+     */
+    public function testShouldNotAcceptStringAsFrameIdInW3cMode()
+    {
+        self::skipForJsonWireProtocol();
+
+        $this->driver->get($this->getTestPageUrl('page_with_frame.html'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'In W3C compliance mode frame must be either instance of WebDriverElement, integer or null'
+        );
+
+        $this->driver->switchTo()->frame('iframe_content');
+    }
+
+    /**
+     * @cover ::frame
+     * @group exclude-saucelabs
+     */
+    public function testShouldAcceptStringAsFrameIdInJsonWireMode()
+    {
+        self::skipForW3cProtocol();
+
+        $this->driver->get($this->getTestPageUrl('page_with_frame.html'));
+
+        $this->driver->switchTo()->frame('iframe_content');
+
+        $this->assertContains('This is the content of the iFrame', $this->driver->getPageSource());
+    }
 }

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -126,7 +126,7 @@ class WebDriverTestCase extends TestCase
     public static function skipForJsonWireProtocol($message = 'Not supported by JsonWire protocol')
     {
         if (getenv('GECKODRIVER') !== '1'
-            && (getenv('CHROMEDRIVER') !== '1' || getenv('DISABLE_W3C_PROTOCOL') === '1')) {
+            && (getenv('BROWSER_NAME') !== 'chrome' || getenv('DISABLE_W3C_PROTOCOL') === '1')) {
             static::markTestSkipped($message);
         }
     }

--- a/tests/functional/web/iframe_content.html
+++ b/tests/functional/web/iframe_content.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>php-webdriver iFrame content page</title>
+</head>
+<body>
+    <p>This is the content of the iFrame</p>
+</body>
+</html>

--- a/tests/functional/web/page_with_frame.html
+++ b/tests/functional/web/page_with_frame.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>php-webdriver test page</title>
+</head>
+<body>
+    <p>This is the host page which contains an iFrame</p>
+    <iframe src="iframe_content.html" name="iframe_content" id="iframe_content"></iframe>
+    <iframe src="open_new_window.html" name="other_iframe_content" id="other_iframe_content"></iframe>
+    <iframe src="upload.html" name="0"></iframe>
+</body>
+</html>


### PR DESCRIPTION
Frame switching W3C Compliance

This change updates the frame functionality to comply with the W3C
specification.

Valid values of the `id` parameter are:
- null
- a Number between 0 and 2^16
- an Object representing a Web element

When the value is null, set the current browsing context to the current
top-level browsing context

When the value is a valid Number, let window be the associated window of
the current browsing context’s active document.

When the value is an Object, let element be the result of trying to get
a known element by web element reference id.

Source: https://www.w3.org/TR/webdriver/#switch-to-frame


I have also included a second commit, shared with #681 to pass isW3cCompliant to the constructor as we do in other classes.