### PR TITLE
Add all W3C WebDriver exceptions

### DIFF
--- a/lib/Exception/ElementClickInterceptedException.php
+++ b/lib/Exception/ElementClickInterceptedException.php
@@ -16,8 +16,9 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * The Element Click command could not be completed because the element receiving the events is obscuring the element
+ * that was requested clicked.
  */
-class InvalidCoordinatesException extends WebDriverException
+class ElementClickInterceptedException extends WebDriverException
 {
 }

--- a/lib/Exception/ElementNotInteractableException.php
+++ b/lib/Exception/ElementNotInteractableException.php
@@ -16,8 +16,8 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * A command could not be completed because the element is not pointer- or keyboard interactable.
  */
-class InvalidCoordinatesException extends WebDriverException
+class ElementNotInteractableException extends WebDriverException
 {
 }

--- a/lib/Exception/ElementNotSelectableException.php
+++ b/lib/Exception/ElementNotSelectableException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
-class ElementNotSelectableException extends WebDriverException
+/**
+ * @deprecated Use Facebook\WebDriver\Exception\ElementNotInteractableException
+ */
+class ElementNotSelectableException extends ElementNotInteractableException
 {
 }

--- a/lib/Exception/ElementNotVisibleException.php
+++ b/lib/Exception/ElementNotVisibleException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * @deprecated Removed in W3C WebDriver
+ */
 class ElementNotVisibleException extends WebDriverException
 {
 }

--- a/lib/Exception/ExpectedException.php
+++ b/lib/Exception/ExpectedException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * @deprecated Removed in W3C WebDriver
+ */
 class ExpectedException extends WebDriverException
 {
 }

--- a/lib/Exception/IMEEngineActivationFailedException.php
+++ b/lib/Exception/IMEEngineActivationFailedException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * @deprecated Removed in W3C WebDriver
+ */
 class IMEEngineActivationFailedException extends WebDriverException
 {
 }

--- a/lib/Exception/IMENotAvailableException.php
+++ b/lib/Exception/IMENotAvailableException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * @deprecated Removed in W3C WebDriver
+ */
 class IMENotAvailableException extends WebDriverException
 {
 }

--- a/lib/Exception/IndexOutOfBoundsException.php
+++ b/lib/Exception/IndexOutOfBoundsException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * @deprecated Removed in W3C WebDriver
+ */
 class IndexOutOfBoundsException extends WebDriverException
 {
 }

--- a/lib/Exception/InsecureCertificateException.php
+++ b/lib/Exception/InsecureCertificateException.php
@@ -16,8 +16,9 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * Navigation caused the user agent to hit a certificate warning, which is usually the result of an expired
+ * or invalid TLS certificate.
  */
-class InvalidCoordinatesException extends WebDriverException
+class InsecureCertificateException extends WebDriverException
 {
 }

--- a/lib/Exception/InvalidArgumentException.php
+++ b/lib/Exception/InvalidArgumentException.php
@@ -16,8 +16,8 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * The arguments passed to a command are either invalid or malformed.
  */
-class InvalidCoordinatesException extends WebDriverException
+class InvalidArgumentException extends WebDriverException
 {
 }

--- a/lib/Exception/InvalidCookieDomainException.php
+++ b/lib/Exception/InvalidCookieDomainException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * An illegal attempt was made to set a cookie under a different domain than the current page.
+ */
 class InvalidCookieDomainException extends WebDriverException
 {
 }

--- a/lib/Exception/InvalidElementStateException.php
+++ b/lib/Exception/InvalidElementStateException.php
@@ -15,6 +15,10 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * A command could not be completed because the element is in an invalid state, e.g. attempting to clear an element
+ * that isn’t both editable and resettable.
+ */
 class InvalidElementStateException extends WebDriverException
 {
 }

--- a/lib/Exception/InvalidSelectorException.php
+++ b/lib/Exception/InvalidSelectorException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * Argument was an invalid selector.
+ */
 class InvalidSelectorException extends WebDriverException
 {
 }

--- a/lib/Exception/InvalidSessionIdException.php
+++ b/lib/Exception/InvalidSessionIdException.php
@@ -16,8 +16,9 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * Occurs if the given session id is not in the list of active sessions, meaning the session either does not exist
+ * or that it’s not active.
  */
-class InvalidCoordinatesException extends WebDriverException
+class InvalidSessionIdException extends WebDriverException
 {
 }

--- a/lib/Exception/JavascriptErrorException.php
+++ b/lib/Exception/JavascriptErrorException.php
@@ -16,8 +16,8 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * An error occurred while executing JavaScript supplied by the user.
  */
-class InvalidCoordinatesException extends WebDriverException
+class JavascriptErrorException extends WebDriverException
 {
 }

--- a/lib/Exception/MoveTargetOutOfBoundsException.php
+++ b/lib/Exception/MoveTargetOutOfBoundsException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * The target for mouse interaction is not in the browser’s viewport and cannot be brought into that viewport.
+ */
 class MoveTargetOutOfBoundsException extends WebDriverException
 {
 }

--- a/lib/Exception/NoAlertOpenException.php
+++ b/lib/Exception/NoAlertOpenException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
-class NoAlertOpenException extends WebDriverException
+/**
+ * @deprecated Use Facebook\WebDriver\Exception\NoSuchAlertException
+ */
+class NoAlertOpenException extends NoSuchAlertException
 {
 }

--- a/lib/Exception/NoCollectionException.php
+++ b/lib/Exception/NoCollectionException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * @deprecated Removed in W3C WebDriver
+ */
 class NoCollectionException extends WebDriverException
 {
 }

--- a/lib/Exception/NoScriptResultException.php
+++ b/lib/Exception/NoScriptResultException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * @deprecated Removed in W3C WebDriver
+ */
 class NoScriptResultException extends WebDriverException
 {
 }

--- a/lib/Exception/NoStringException.php
+++ b/lib/Exception/NoStringException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * @deprecated Removed in W3C WebDriver
+ */
 class NoStringException extends WebDriverException
 {
 }

--- a/lib/Exception/NoStringLengthException.php
+++ b/lib/Exception/NoStringLengthException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * @deprecated Removed in W3C WebDriver
+ */
 class NoStringLengthException extends WebDriverException
 {
 }

--- a/lib/Exception/NoStringWrapperException.php
+++ b/lib/Exception/NoStringWrapperException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * @deprecated Removed in W3C WebDriver
+ */
 class NoStringWrapperException extends WebDriverException
 {
 }

--- a/lib/Exception/NoSuchAlertException.php
+++ b/lib/Exception/NoSuchAlertException.php
@@ -16,8 +16,8 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * An attempt was made to operate on a modal dialog when one was not open.
  */
-class InvalidCoordinatesException extends WebDriverException
+class NoSuchAlertException extends WebDriverException
 {
 }

--- a/lib/Exception/NoSuchCollectionException.php
+++ b/lib/Exception/NoSuchCollectionException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * @deprecated Removed in W3C WebDriver
+ */
 class NoSuchCollectionException extends WebDriverException
 {
 }

--- a/lib/Exception/NoSuchCookieException.php
+++ b/lib/Exception/NoSuchCookieException.php
@@ -16,8 +16,9 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * No cookie matching the given path name was found amongst the associated cookies of the current browsing context’s
+ * active document.
  */
-class InvalidCoordinatesException extends WebDriverException
+class NoSuchCookieException extends WebDriverException
 {
 }

--- a/lib/Exception/NoSuchDocumentException.php
+++ b/lib/Exception/NoSuchDocumentException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
-class NoSuchDocumentException extends WebDriverException
+/**
+ * @deprecated Use Facebook\WebDriver\Exception\NoSuchWindowException
+ */
+class NoSuchDocumentException extends NoSuchWindowException
 {
 }

--- a/lib/Exception/NoSuchDriverException.php
+++ b/lib/Exception/NoSuchDriverException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * @deprecated Removed in W3C WebDriver
+ */
 class NoSuchDriverException extends WebDriverException
 {
 }

--- a/lib/Exception/NoSuchElementException.php
+++ b/lib/Exception/NoSuchElementException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * An element could not be located on the page using the given search parameters.
+ */
 class NoSuchElementException extends WebDriverException
 {
 }

--- a/lib/Exception/NoSuchFrameException.php
+++ b/lib/Exception/NoSuchFrameException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * A command to switch to a frame could not be satisfied because the frame could not be found.
+ */
 class NoSuchFrameException extends WebDriverException
 {
 }

--- a/lib/Exception/NoSuchWindowException.php
+++ b/lib/Exception/NoSuchWindowException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * A command to switch to a window could not be satisfied because the window could not be found.
+ */
 class NoSuchWindowException extends WebDriverException
 {
 }

--- a/lib/Exception/NullPointerException.php
+++ b/lib/Exception/NullPointerException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * @deprecated Removed in W3C WebDriver
+ */
 class NullPointerException extends WebDriverException
 {
 }

--- a/lib/Exception/ScriptTimeoutException.php
+++ b/lib/Exception/ScriptTimeoutException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * A script did not complete before its timeout expired.
+ */
 class ScriptTimeoutException extends WebDriverException
 {
 }

--- a/lib/Exception/SessionNotCreatedException.php
+++ b/lib/Exception/SessionNotCreatedException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * A new session could not be created.
+ */
 class SessionNotCreatedException extends WebDriverException
 {
 }

--- a/lib/Exception/StaleElementReferenceException.php
+++ b/lib/Exception/StaleElementReferenceException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * A command failed because the referenced element is no longer attached to the DOM.
+ */
 class StaleElementReferenceException extends WebDriverException
 {
 }

--- a/lib/Exception/TimeoutException.php
+++ b/lib/Exception/TimeoutException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
-class TimeOutException extends WebDriverException
+/**
+ * An operation did not complete before its timeout expired.
+ */
+class TimeoutException extends WebDriverException
 {
 }

--- a/lib/Exception/UnableToCaptureScreenException.php
+++ b/lib/Exception/UnableToCaptureScreenException.php
@@ -16,8 +16,8 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * A screen capture was made impossible.
  */
-class InvalidCoordinatesException extends WebDriverException
+class UnableToCaptureScreenException extends WebDriverException
 {
 }

--- a/lib/Exception/UnableToSetCookieException.php
+++ b/lib/Exception/UnableToSetCookieException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * A command to set a cookie’s value could not be satisfied.
+ */
 class UnableToSetCookieException extends WebDriverException
 {
 }

--- a/lib/Exception/UnexpectedAlertOpenException.php
+++ b/lib/Exception/UnexpectedAlertOpenException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * A modal dialog was open, blocking this operation.
+ */
 class UnexpectedAlertOpenException extends WebDriverException
 {
 }

--- a/lib/Exception/UnexpectedJavascriptException.php
+++ b/lib/Exception/UnexpectedJavascriptException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
-class UnexpectedJavascriptException extends WebDriverException
+/**
+ * @deprecated Use Facebook\WebDriver\Exception\JavascriptErrorException
+ */
+class UnexpectedJavascriptException extends JavascriptErrorException
 {
 }

--- a/lib/Exception/UnknownCommandException.php
+++ b/lib/Exception/UnknownCommandException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * A command could not be executed because the remote end is not aware of it.
+ */
 class UnknownCommandException extends WebDriverException
 {
 }

--- a/lib/Exception/UnknownErrorException.php
+++ b/lib/Exception/UnknownErrorException.php
@@ -16,8 +16,8 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * An unknown error occurred in the remote end while processing the command.
  */
-class InvalidCoordinatesException extends WebDriverException
+class UnknownErrorException extends WebDriverException
 {
 }

--- a/lib/Exception/UnknownMethodException.php
+++ b/lib/Exception/UnknownMethodException.php
@@ -16,8 +16,8 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * The requested command matched a known URL but did not match an method for that URL.
  */
-class InvalidCoordinatesException extends WebDriverException
+class UnknownMethodException extends WebDriverException
 {
 }

--- a/lib/Exception/UnknownServerException.php
+++ b/lib/Exception/UnknownServerException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
-class UnknownServerException extends WebDriverException
+/**
+ * @deprecated Use Facebook\WebDriver\Exception\UnknownErrorException
+ */
+class UnknownServerException extends UnknownErrorException
 {
 }

--- a/lib/Exception/UnsupportedOperationException.php
+++ b/lib/Exception/UnsupportedOperationException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * Indicates that a command that should have executed properly cannot be supported for some reason.
+ */
 class UnsupportedOperationException extends WebDriverException
 {
 }

--- a/lib/Exception/WebDriverException.php
+++ b/lib/Exception/WebDriverException.php
@@ -17,6 +17,9 @@ namespace Facebook\WebDriver\Exception;
 
 use Exception;
 
+/**
+ * @see https://w3c.github.io/webdriver/#errors
+ */
 class WebDriverException extends Exception
 {
     private $results;
@@ -46,16 +49,22 @@ class WebDriverException extends Exception
      * @param string $message
      * @param mixed $results
      *
+     * @throws ElementClickInterceptedException
+     * @throws ElementNotInteractableException
      * @throws ElementNotSelectableException
      * @throws ElementNotVisibleException
      * @throws ExpectedException
      * @throws IMEEngineActivationFailedException
      * @throws IMENotAvailableException
      * @throws IndexOutOfBoundsException
+     * @throws InsecureCertificateException
+     * @throws InvalidArgumentException
      * @throws InvalidCookieDomainException
      * @throws InvalidCoordinatesException
      * @throws InvalidElementStateException
      * @throws InvalidSelectorException
+     * @throws InvalidSessionIdException
+     * @throws JavascriptErrorException
      * @throws MoveTargetOutOfBoundsException
      * @throws NoAlertOpenException
      * @throws NoCollectionException
@@ -63,7 +72,9 @@ class WebDriverException extends Exception
      * @throws NoStringException
      * @throws NoStringLengthException
      * @throws NoStringWrapperException
+     * @throws NoSuchAlertException
      * @throws NoSuchCollectionException
+     * @throws NoSuchCookieException
      * @throws NoSuchDocumentException
      * @throws NoSuchDriverException
      * @throws NoSuchElementException
@@ -73,61 +84,76 @@ class WebDriverException extends Exception
      * @throws ScriptTimeoutException
      * @throws SessionNotCreatedException
      * @throws StaleElementReferenceException
-     * @throws TimeOutException
+     * @throws TimeoutException
+     * @throws UnableToCaptureScreenException
      * @throws UnableToSetCookieException
      * @throws UnexpectedAlertOpenException
      * @throws UnexpectedJavascriptException
      * @throws UnknownCommandException
+     * @throws UnknownErrorException
+     * @throws UnknownMethodException
      * @throws UnknownServerException
      * @throws UnrecognizedExceptionException
-     * @throws WebDriverCurlException
+     * @throws UnsupportedOperationException
      * @throws XPathLookupException
      */
     public static function throwException($status_code, $message, $results)
     {
         if (is_string($status_code)) {
-            // see https://w3c.github.io/webdriver/webdriver-spec.html#handling-errors
+            // @see https://w3c.github.io/webdriver/#errors
             switch ($status_code) {
+                case 'element click intercepted':
+                    throw new ElementClickInterceptedException($message, $results);
+                case 'element not interactable':
+                    throw new ElementNotInteractableException($message, $results);
+                case 'insecure certificate':
+                    throw new InsecureCertificateException($message, $results);
+                case 'invalid argument':
+                    throw new InvalidArgumentException($message, $results);
+                case 'invalid cookie domain':
+                    throw new InvalidCookieDomainException($message, $results);
+                case 'invalid element state':
+                    throw new InvalidElementStateException($message, $results);
+                case 'invalid selector':
+                    throw new InvalidSelectorException($message, $results);
+                case 'invalid session id':
+                    throw new InvalidSessionIdException($message, $results);
+                case 'javascript error':
+                    throw new JavascriptErrorException($message, $results);
+                case 'move target out of bounds':
+                    throw new MoveTargetOutOfBoundsException($message, $results);
+                case 'no such alert':
+                    throw new NoSuchAlertException($message, $results);
+                case 'no such cookie':
+                    throw new NoSuchCookieException($message, $results);
                 case 'no such element':
                     throw new NoSuchElementException($message, $results);
                 case 'no such frame':
                     throw new NoSuchFrameException($message, $results);
-                case 'unknown command':
-                    throw new UnknownCommandException($message, $results);
-                case 'stale element reference':
-                    throw new StaleElementReferenceException($message, $results);
-                case 'invalid element state':
-                    throw new InvalidElementStateException($message, $results);
-                case 'unknown error':
-                    throw new UnknownServerException($message, $results);
-                case 'unsupported operation':
-                    throw new ExpectedException($message, $results);
-                case 'element not interactable':
-                    throw new ElementNotSelectableException($message, $results);
-                case 'no such window':
-                    throw new NoSuchDocumentException($message, $results);
-                case 'javascript error':
-                    throw new UnexpectedJavascriptException($message, $results);
-                case 'timeout':
-                    throw new TimeOutException($message, $results);
                 case 'no such window':
                     throw new NoSuchWindowException($message, $results);
-                case 'invalid cookie domain':
-                    throw new InvalidCookieDomainException($message, $results);
-                case 'unable to set cookie':
-                    throw new UnableToSetCookieException($message, $results);
-                case 'unexpected alert open':
-                    throw new UnexpectedAlertOpenException($message, $results);
-                case 'no such alert':
-                    throw new NoAlertOpenException($message, $results);
                 case 'script timeout':
                     throw new ScriptTimeoutException($message, $results);
-                case 'invalid selector':
-                    throw new InvalidSelectorException($message, $results);
                 case 'session not created':
                     throw new SessionNotCreatedException($message, $results);
-                case 'move target out of bounds':
-                    throw new MoveTargetOutOfBoundsException($message, $results);
+                case 'stale element reference':
+                    throw new StaleElementReferenceException($message, $results);
+                case 'timeout':
+                    throw new TimeoutException($message, $results);
+                case 'unable to set cookie':
+                    throw new UnableToSetCookieException($message, $results);
+                case 'unable to capture screen':
+                    throw new UnableToCaptureScreenException($message, $results);
+                case 'unexpected alert open':
+                    throw new UnexpectedAlertOpenException($message, $results);
+                case 'unknown command':
+                    throw new UnknownCommandException($message, $results);
+                case 'unknown error':
+                    throw new UnknownErrorException($message, $results);
+                case 'unknown method':
+                    throw new UnknownMethodException($message, $results);
+                case 'unsupported operation':
+                    throw new UnsupportedOperationException($message, $results);
                 default:
                     throw new UnrecognizedExceptionException($message, $results);
             }
@@ -175,7 +201,7 @@ class WebDriverException extends Exception
             case 20:
                 throw new NoSuchCollectionException($message, $results);
             case 21:
-                throw new TimeOutException($message, $results);
+                throw new TimeoutException($message, $results);
             case 22:
                 throw new NullPointerException($message, $results);
             case 23:

--- a/lib/Exception/XPathLookupException.php
+++ b/lib/Exception/XPathLookupException.php
@@ -15,6 +15,9 @@
 
 namespace Facebook\WebDriver\Exception;
 
+/**
+ * @deprecated Removed in W3C WebDriver
+ */
 class XPathLookupException extends WebDriverException
 {
 }

--- a/lib/Net/URLChecker.php
+++ b/lib/Net/URLChecker.php
@@ -16,7 +16,7 @@
 namespace Facebook\WebDriver\Net;
 
 use Exception;
-use Facebook\WebDriver\Exception\TimeOutException;
+use Facebook\WebDriver\Exception\TimeoutException;
 
 class URLChecker
 {
@@ -34,7 +34,7 @@ class URLChecker
             usleep(self::POLL_INTERVAL_MS);
         }
 
-        throw new TimeOutException(sprintf(
+        throw new TimeoutException(sprintf(
             'Timed out waiting for %s to become available after %d ms.',
             $url,
             $timeout_in_ms
@@ -52,7 +52,7 @@ class URLChecker
             usleep(self::POLL_INTERVAL_MS);
         }
 
-        throw new TimeOutException(sprintf(
+        throw new TimeoutException(sprintf(
             'Timed out waiting for %s to become unavailable after %d ms.',
             $url,
             $timeout_in_ms

--- a/lib/WebDriverWait.php
+++ b/lib/WebDriverWait.php
@@ -16,7 +16,7 @@
 namespace Facebook\WebDriver;
 
 use Facebook\WebDriver\Exception\NoSuchElementException;
-use Facebook\WebDriver\Exception\TimeOutException;
+use Facebook\WebDriver\Exception\TimeoutException;
 
 /**
  * A utility class, designed to help the user to wait until a condition turns true.
@@ -52,7 +52,7 @@ class WebDriverWait
      * @param string $message
      *
      * @throws NoSuchElementException
-     * @throws TimeOutException
+     * @throws TimeoutException
      * @throws \Exception
      * @return mixed The return value of $func_or_ec
      */
@@ -81,6 +81,6 @@ class WebDriverWait
             throw $last_exception;
         }
 
-        throw new TimeOutException($message);
+        throw new TimeoutException($message);
     }
 }

--- a/tests/functional/WebDriverAlertTest.php
+++ b/tests/functional/WebDriverAlertTest.php
@@ -16,6 +16,7 @@
 namespace Facebook\WebDriver;
 
 use Facebook\WebDriver\Exception\NoAlertOpenException;
+use Facebook\WebDriver\Exception\NoSuchAlertException;
 use Facebook\WebDriver\Remote\WebDriverBrowserType;
 
 /**
@@ -42,7 +43,12 @@ class WebDriverAlertTest extends WebDriverTestCase
 
         $this->driver->switchTo()->alert()->accept();
 
-        $this->expectException(NoAlertOpenException::class);
+        if (self::isW3cProtocolBuild()) {
+            $this->expectException(NoSuchAlertException::class);
+        } else {
+            $this->expectException(NoAlertOpenException::class);
+        }
+
         $this->driver->switchTo()->alert()->accept();
     }
 

--- a/tests/functional/WebDriverTimeoutsTest.php
+++ b/tests/functional/WebDriverTimeoutsTest.php
@@ -17,7 +17,7 @@ namespace Facebook\WebDriver;
 
 use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\Exception\ScriptTimeoutException;
-use Facebook\WebDriver\Exception\TimeOutException;
+use Facebook\WebDriver\Exception\TimeoutException;
 use Facebook\WebDriver\Remote\RemoteWebElement;
 use Facebook\WebDriver\Remote\WebDriverBrowserType;
 
@@ -65,8 +65,8 @@ class WebDriverTimeoutsTest extends WebDriverTestCase
 
         try {
             $this->driver->get($this->getTestPageUrl('slow_loading.html'));
-            $this->fail('ScriptTimeoutException or TimeOutException exception should be thrown');
-        } catch (TimeOutException $e) { // thrown by Selenium 3.0.0+
+            $this->fail('ScriptTimeoutException or TimeoutException exception should be thrown');
+        } catch (TimeoutException $e) { // thrown by Selenium 3.0.0+
         } catch (ScriptTimeoutException $e) { // thrown by Selenium 2
         }
     }

--- a/tests/unit/Exception/WebDriverExceptionTest.php
+++ b/tests/unit/Exception/WebDriverExceptionTest.php
@@ -29,14 +29,15 @@ class WebDriverExceptionTest extends TestCase
     }
 
     /**
-     * @dataProvider statusCodeProvider
-     * @param int $statusCode
+     * @dataProvider jsonWireStatusCodeProvider
+     * @dataProvider w3CWebDriverErrorCodeProvider
+     * @param int $errorCode
      * @param string $expectedExceptionType
      */
-    public function testShouldThrowProperExceptionBasedOnSeleniumStatusCode($statusCode, $expectedExceptionType)
+    public function testShouldThrowProperExceptionBasedOnWebDriverErrorCode($errorCode, $expectedExceptionType)
     {
         try {
-            WebDriverException::throwException($statusCode, 'exception message', ['results']);
+            WebDriverException::throwException($errorCode, 'exception message', ['results']);
         } catch (WebDriverException $e) {
             $this->assertInstanceOf($expectedExceptionType, $e);
 
@@ -48,7 +49,7 @@ class WebDriverExceptionTest extends TestCase
     /**
      * @return array[]
      */
-    public function statusCodeProvider()
+    public function jsonWireStatusCodeProvider()
     {
         return [
             [1337, UnrecognizedExceptionException::class],
@@ -72,7 +73,7 @@ class WebDriverExceptionTest extends TestCase
             [18, NoScriptResultException::class],
             [19, XPathLookupException::class],
             [20, NoSuchCollectionException::class],
-            [21, TimeOutException::class],
+            [21, TimeoutException::class],
             [22, NullPointerException::class],
             [23, NoSuchWindowException::class],
             [24, InvalidCookieDomainException::class],
@@ -86,6 +87,42 @@ class WebDriverExceptionTest extends TestCase
             [32, InvalidSelectorException::class],
             [33, SessionNotCreatedException::class],
             [34, MoveTargetOutOfBoundsException::class],
+        ];
+    }
+
+    /**
+     * @return array[]
+     */
+    public function w3CWebDriverErrorCodeProvider()
+    {
+        return [
+                ['element click intercepted', ElementClickInterceptedException::class],
+                ['element not interactable', ElementNotInteractableException::class],
+                ['element not interactable', ElementNotInteractableException::class],
+                ['insecure certificate', InsecureCertificateException::class],
+                ['invalid argument', InvalidArgumentException::class],
+                ['invalid cookie domain', InvalidCookieDomainException::class],
+                ['invalid element state', InvalidElementStateException::class],
+                ['invalid selector', InvalidSelectorException::class],
+                ['invalid session id', InvalidSessionIdException::class],
+                ['javascript error', JavascriptErrorException::class],
+                ['move target out of bounds', MoveTargetOutOfBoundsException::class],
+                ['no such alert', NoSuchAlertException::class],
+                ['no such cookie', NoSuchCookieException::class],
+                ['no such element', NoSuchElementException::class],
+                ['no such frame', NoSuchFrameException::class],
+                ['no such window', NoSuchWindowException::class],
+                ['script timeout', ScriptTimeoutException::class],
+                ['session not created', SessionNotCreatedException::class],
+                ['stale element reference', StaleElementReferenceException::class],
+                ['timeout', TimeoutException::class],
+                ['unable to set cookie', UnableToSetCookieException::class],
+                ['unable to capture screen', UnableToCaptureScreenException::class],
+                ['unexpected alert open', UnexpectedAlertOpenException::class],
+                ['unknown command', UnknownCommandException::class],
+                ['unknown error', UnknownErrorException::class],
+                ['unknown method', UnknownMethodException::class],
+                ['unsupported operation', UnsupportedOperationException::class],
         ];
     }
 }


### PR DESCRIPTION
Implements all W3C WebDriver exceptions according to https://w3c.github.io/webdriver/#errors.

Those which didn't make it to the new standard are marked as deprecated.

Ref. #469 