### PR TITLE
Control + Command swapped when Platform is MacOS

### DIFF
--- a/tests/functional/RemoteKeyboardTest.php
+++ b/tests/functional/RemoteKeyboardTest.php
@@ -1,0 +1,60 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Facebook\WebDriver;
+
+use Facebook\WebDriver\Remote\DriverCommand;
+use Facebook\WebDriver\WebDriverKeys;
+
+/**
+ * @coversDefaultClass \Facebook\WebDriver\Remote\RemoteKeyboard
+ */
+class RemoteKeyboardTest extends WebDriverTestCase
+{
+    /**
+     * @covers ::getTitle
+     */
+    public function testShouldGetPageTitle()
+    {
+        //self::skipForJsonWireProtocol();
+
+        $this->driver->get($this->getTestPageUrl('form.html'));
+
+        $input = $this->driver->findElement(WebDriverBy::id('input-text'));
+        $input->click();
+
+        $this->driver->execute(DriverCommand::ACTIONS, [
+            'actions' => [
+                [
+                    'type' => 'key',
+                    'id' => 'keyboard',
+                    'actions' => [
+                        ['type' => 'keyDown', 'value' => WebDriverKeys::COMMAND],
+                        ['type' => 'keyDown', 'value' => 'a'],
+                        ['type' => 'keyUp', 'value' => 'a'],
+                        ['type' => 'keyUp', 'value' => WebDriverKeys::COMMAND],
+                        ['type' => 'keyDown', 'value' => WebDriverKeys::BACKSPACE],
+                        ['type' => 'keyUp', 'value' => WebDriverKeys::BACKSPACE],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals(
+            '',
+            $input->getAttribute('value')
+        );
+    }
+}


### PR DESCRIPTION
### What are you trying to achieve? (Expected behavior)
When I use the WebDriverKey::CONTROL on a Mac, using Firefox and Chrome, the CONTROL key and COMMAND key are swapped around.

Arguably this is correct because on a Mac the COMMAND hey performs as the CONTROL key on Linux/Windows (i.e. they actually _are_ swapped around), but I feel that this should be handled within the driver.

### What do you get instead? (Actual behavior)
Instead of CONTROL I get the action of COMMAND

### How could the issue be reproduced? (Steps to reproduce)
Unit test.

Note: the WebDriverTestCase prevents you from running Firefox via Selenium properly. The `skipForJsonWireProtocol` function skips unless GECKODRIVER=1 hence the relevant line being commented out.

```php
<?php
// Copyright 2004-present Facebook. All Rights Reserved.
//
// Licensed under the Apache License, Version 2.0 (the "License");
// you may not use this file except in compliance with the License.
// You may obtain a copy of the License at
//
//     http://www.apache.org/licenses/LICENSE-2.0
//
// Unless required by applicable law or agreed to in writing, software
// distributed under the License is distributed on an "AS IS" BASIS,
// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
// See the License for the specific language governing permissions and
// limitations under the License.

namespace Facebook\WebDriver;

use Facebook\WebDriver\Remote\DriverCommand;
use Facebook\WebDriver\WebDriverKeys;

/**
 * @coversDefaultClass \Facebook\WebDriver\Remote\RemoteKeyboard
 */
class RemoteKeyboardTest extends WebDriverTestCase
{
    /**
     * @covers ::getTitle
     */
    public function testShouldGetPageTitle()
    {
        //self::skipForJsonWireProtocol();

        $this->driver->get($this->getTestPageUrl('form.html'));

        $input = $this->driver->findElement(WebDriverBy::id('input-text'));
        $input->click();

        $this->driver->execute(DriverCommand::ACTIONS, [
            'actions' => [
                [
                    'type' => 'key',
                    'id' => 'keyboard',
                    'actions' => [
                        ['type' => 'keyDown', 'value' => WebDriverKeys::COMMAND],
                        ['type' => 'keyDown', 'value' => 'a'],
                        ['type' => 'keyUp', 'value' => 'a'],
                        ['type' => 'keyUp', 'value' => WebDriverKeys::COMMAND],
                        ['type' => 'keyDown', 'value' => WebDriverKeys::BACKSPACE],
                        ['type' => 'keyUp', 'value' => WebDriverKeys::BACKSPACE],
                    ],
                ],
            ],
        ]);

        readline('Check');
        $this->assertEquals(
            '',
            $input->getAttribute('value')
        );
    }
}
```

### Details
<!-- Please fill relevant following versions: -->

* Php-webdriver version: community
* PHP version: 7.3.11
* Selenium server version: 3.141.59
* Operating system: MacOS + Docker Linux
* Browser used + version: Firefox 70.0.1, Chrome 78.0.3904.108
