### PR TITLE
Allow specification of firefox options for non-gecko

### DIFF
--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -63,8 +63,10 @@ class WebDriverTestCase extends TestCase
                 }
 
                 $this->desiredCapabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);
-            } elseif (getenv('GECKODRIVER') === '1') {
-                $this->serverUrl = 'http://localhost:4444';
+            } elseif ($browserName === WebDriverBrowserType::FIREFOX) {
+                if (getenv('GECKODRIVER') === '1') {
+                    $this->serverUrl = 'http://localhost:4444';
+                }
                 $this->desiredCapabilities->setCapability(
                     'moz:firefoxOptions',
                     ['args' => ['-headless']]


### PR DESCRIPTION
Note: This just allows us to specify options like headless.
I have not:
* fixed the `skipForJsonWireProtocol` issue . I think that we need a non-static version of these functions which checks the W3C attribute of the driver instance.
* added any new options. I was tempted to add `['log' => ['level' => 'trace']]` to aid debugging. Currently I"m adding that manually