### PR TITLE
Allow specification of alternate host for fixtures

### DIFF
--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -139,7 +139,12 @@ class WebDriverTestCase extends TestCase
      */
     protected function getTestPageUrl($path)
     {
-        return 'http://localhost:8000/' . $path;
+        $host = 'http://localhost:8000';
+        if ($alternateHost = getenv('FIXTURES_HOST')) {
+            $host = $alternateHost;
+        }
+
+        return $host . '/' . $path;
     }
 
     protected function setUpSauceLabs()


### PR DESCRIPTION
To allow me to test using docker images, I have to manually edit the `getTestPgeUrl` function in the Driver testcase.

This is just a small change to allow the fixtures host to be specified as an environment variable called `FIXTURES_HOST`.