### PR TITLE
Remove platform ANY from required capabilities

### DIFF
--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -199,9 +199,10 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
+     * @param bool $forRequiredCapabilities
      * @return array
      */
-    public function toW3cCompatibleArray()
+    public function toW3cCompatibleArray($forRequiredCapabilities = false)
     {
         $allowedW3cCapabilities = [
             'browserName',
@@ -228,7 +229,9 @@ class DesiredCapabilities implements WebDriverCapabilities
             // Convert capabilities with changed name
             if (array_key_exists($capabilityKey, static::$ossToW3c)) {
                 if ($capabilityKey === WebDriverCapabilityType::PLATFORM) {
-                    $w3cCapabilities[static::$ossToW3c[$capabilityKey]] = mb_strtolower($capabilityValue);
+                    if (!$forRequiredCapabilities || $capabilityValue !== WebDriverPlatform::ANY) {
+                        $w3cCapabilities[static::$ossToW3c[$capabilityKey]] = mb_strtolower($capabilityValue);
+                    }
                 } else {
                     $w3cCapabilities[static::$ossToW3c[$capabilityKey]] = $capabilityValue;
                 }

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -120,14 +120,19 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         }
 
         // W3C
-        $parameters = [
-            'capabilities' => [
-                'firstMatch' => [$desired_capabilities->toW3cCompatibleArray()],
-            ],
-        ];
+        $parameters = [];
+        $firstMatch = $desired_capabilities->toW3cCompatibleArray(true);
+        if (!empty($firstMatch)) {
+            $parameters['capabilities'] = [
+                'firstMatch' => [$desired_capabilities->toW3cCompatibleArray(true)],
+            ];
+        }
 
-        if ($required_capabilities !== null && !empty($required_capabilities->toArray())) {
-            $parameters['capabilities']['alwaysMatch'] = $required_capabilities->toW3cCompatibleArray();
+        if ($required_capabilities !== null) {
+            $alwaysMatch = $required_capabilities->toW3cCompatibleArray(true);
+            if (!empty($alwaysMatch)) {
+                $parameters['capabilities']['alwaysMatch'] = $alwaysMatch;
+            }
         }
 
         // Legacy protocol
@@ -138,7 +143,9 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
             $desired_capabilities->setCapability('requiredCapabilities', $required_capabilities->toArray());
         }
 
-        $parameters['desiredCapabilities'] = $desired_capabilities->toArray();
+        if (!empty($desired_capabilities->toArray())) {
+            $parameters['desiredCapabilities'] = $desired_capabilities->toArray();
+        }
 
         $command = new WebDriverCommand(
             null,

--- a/tests/functional/RemoteWebDriverCreateTest.php
+++ b/tests/functional/RemoteWebDriverCreateTest.php
@@ -106,4 +106,87 @@ class RemoteWebDriverCreateTest extends WebDriverTestCase
         // Check we reused the previous instance (window) and it has the same URL
         $this->assertContains('/index.html', $this->driver->getCurrentURL());
     }
+
+    public function testShouldRemoveAnyPlatformFromFirstMatch()
+    {
+        $this->desiredCapabilities->setPlatform(WebDriverPlatform::ANY);
+
+        $this->driver = RemoteWebDriver::create(
+            $this->serverUrl,
+            $this->desiredCapabilities,
+            $this->connectionTimeout,
+            $this->requestTimeout,
+            null,
+            null,
+            null
+        );
+
+        $this->assertInstanceOf(RemoteWebDriver::class, $this->driver);
+
+        $this->assertInstanceOf(HttpCommandExecutor::class, $this->driver->getCommandExecutor());
+        $this->assertNotEmpty($this->driver->getCommandExecutor()->getAddressOfRemoteServer());
+
+        $this->assertInternalType('string', $this->driver->getSessionID());
+        $this->assertNotEmpty($this->driver->getSessionID());
+
+        $returnedCapabilities = $this->driver->getCapabilities();
+        $this->assertInstanceOf(WebDriverCapabilities::class, $returnedCapabilities);
+        $this->assertSame($this->desiredCapabilities->getBrowserName(), $returnedCapabilities->getBrowserName());
+    }
+
+    public function testShouldRemoveAnyPlatformFromAlwaysMatch()
+    {
+        $this->desiredCapabilities->setPlatform(WebDriverPlatform::ANY);
+        $alwaysMatch = new DesiredCapabilities();
+        $alwaysMatch->setPlatform(WebDriverPlatform::ANY);
+
+        $this->driver = RemoteWebDriver::create(
+            $this->serverUrl,
+            $this->desiredCapabilities,
+            $this->connectionTimeout,
+            $this->requestTimeout,
+            null,
+            null,
+            $alwaysMatch,
+        );
+
+        $this->assertInstanceOf(RemoteWebDriver::class, $this->driver);
+
+        $this->assertInstanceOf(HttpCommandExecutor::class, $this->driver->getCommandExecutor());
+        $this->assertNotEmpty($this->driver->getCommandExecutor()->getAddressOfRemoteServer());
+
+        $this->assertInternalType('string', $this->driver->getSessionID());
+        $this->assertNotEmpty($this->driver->getSessionID());
+
+        $returnedCapabilities = $this->driver->getCapabilities();
+        $this->assertInstanceOf(WebDriverCapabilities::class, $returnedCapabilities);
+        $this->assertSame($this->desiredCapabilities->getBrowserName(), $returnedCapabilities->getBrowserName());
+    }
+
+    public function testShouldRemoveAnyPlatformFromFirstMatchEmptyDesired()
+    {
+        $desiredCapabilities = new DesiredCapabilities();
+        $desiredCapabilities->setPlatform(WebDriverPlatform::ANY);
+
+        $this->driver = RemoteWebDriver::create(
+            $this->serverUrl,
+            $desiredCapabilities,
+            $this->connectionTimeout,
+            $this->requestTimeout,
+            null,
+            null,
+            null
+        );
+
+        $this->assertInstanceOf(RemoteWebDriver::class, $this->driver);
+
+        $this->assertInstanceOf(HttpCommandExecutor::class, $this->driver->getCommandExecutor());
+        $this->assertNotEmpty($this->driver->getCommandExecutor()->getAddressOfRemoteServer());
+
+        $this->assertInternalType('string', $this->driver->getSessionID());
+        $this->assertNotEmpty($this->driver->getSessionID());
+
+        $returnedCapabilities = $this->driver->getCapabilities();
+        $this->assertInstanceOf(WebDriverCapabilities::class, $returnedCapabilities);
+    }
 }

--- a/tests/unit/Remote/DesiredCapabilitiesTest.php
+++ b/tests/unit/Remote/DesiredCapabilitiesTest.php
@@ -139,11 +139,12 @@ class DesiredCapabilitiesTest extends TestCase
      */
     public function testShouldConvertCapabilitiesToW3cCompatible(
         DesiredCapabilities $inputJsonWireCapabilities,
+        bool $forRequiredCapabilities,
         array $expectedW3cCapabilities
     ) {
         $this->assertEquals(
             $expectedW3cCapabilities,
-            $inputJsonWireCapabilities->toW3cCompatibleArray()
+            $inputJsonWireCapabilities->toW3cCompatibleArray($forRequiredCapabilities)
         );
     }
 
@@ -167,6 +168,7 @@ class DesiredCapabilitiesTest extends TestCase
                     WebDriverCapabilityType::PLATFORM => WebDriverPlatform::LINUX,
                     WebDriverCapabilityType::ACCEPT_SSL_CERTS => true,
                 ]),
+                false,
                 [
                     'browserName' => 'chrome',
                     'browserVersion' => '67.0.1',
@@ -179,12 +181,14 @@ class DesiredCapabilitiesTest extends TestCase
                     WebDriverCapabilityType::WEB_STORAGE_ENABLED => true,
                     WebDriverCapabilityType::TAKES_SCREENSHOT => false,
                 ]),
+                false,
                 [],
             ],
             'custom invalid capability should be removed' => [
                 new DesiredCapabilities([
                     'customInvalidCapability' => 'shouldBeRemoved',
                 ]),
+                false,
                 [],
             ],
             'already W3C capabilitites' => [
@@ -192,6 +196,7 @@ class DesiredCapabilitiesTest extends TestCase
                     'pageLoadStrategy' => 'eager',
                     'strictFileInteractability' => false,
                 ]),
+                false,
                 [
                     'pageLoadStrategy' => 'eager',
                     'strictFileInteractability' => false,
@@ -201,6 +206,7 @@ class DesiredCapabilitiesTest extends TestCase
                 new DesiredCapabilities([
                     'vendor:prefix' => 'vendor extension should be kept',
                 ]),
+                false,
                 [
                     'vendor:prefix' => 'vendor extension should be kept',
                 ],
@@ -209,6 +215,7 @@ class DesiredCapabilitiesTest extends TestCase
                 new DesiredCapabilities([
                     ChromeOptions::CAPABILITY => $chromeOptions,
                 ]),
+                false,
                 [
                     'goog:chromeOptions' => [
                         'args' => ['--headless'],
@@ -224,6 +231,7 @@ class DesiredCapabilitiesTest extends TestCase
                         'args' => ['window-size=1024,768'],
                     ],
                 ]),
+                false,
                 [
                     'goog:chromeOptions' => [
                         'args' => ['--headless', 'window-size=1024,768'],
@@ -236,6 +244,7 @@ class DesiredCapabilitiesTest extends TestCase
                 new DesiredCapabilities([
                     FirefoxDriver::PROFILE => $firefoxProfileEncoded,
                 ]),
+                false,
                 [
                     'moz:firefoxOptions' => [
                         'profile' => $firefoxProfileEncoded,
@@ -247,6 +256,7 @@ class DesiredCapabilitiesTest extends TestCase
                     FirefoxDriver::PROFILE => $firefoxProfileEncoded,
                     'moz:firefoxOptions' => ['profile' => 'w3cProfile'],
                 ]),
+                false,
                 [
                     'moz:firefoxOptions' => [
                         'profile' => 'w3cProfile',
@@ -258,11 +268,44 @@ class DesiredCapabilitiesTest extends TestCase
                     FirefoxDriver::PROFILE => $firefoxProfileEncoded,
                     'moz:firefoxOptions' => ['args' => ['-headless']],
                 ]),
+                false,
                 [
                     'moz:firefoxOptions' => [
                         'profile' => $firefoxProfileEncoded,
                         'args' => ['-headless'],
                     ],
+                ],
+            ],
+            'platform of any should be removed from requiredCapabilities' => [
+                new DesiredCapabilities([
+                    WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::FIREFOX,
+                    WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
+                ]),
+                true,
+                [
+                    'browserName' => 'firefox',
+                ],
+            ],
+            'platform of any should not be removed from desiredCapabilities' => [
+                new DesiredCapabilities([
+                    WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::FIREFOX,
+                    WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
+                ]),
+                false,
+                [
+                    'browserName' => 'firefox',
+                    'platformName' => 'any',
+                ],
+            ],
+            'platform name of linux should not be removed from requiredCapabilities' => [
+                new DesiredCapabilities([
+                    WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::FIREFOX,
+                    WebDriverCapabilityType::PLATFORM => WebDriverPlatform::LINUX,
+                ]),
+                true,
+                [
+                    'browserName' => 'firefox',
+                    'platformName' => 'linux',
                 ],
             ],
         ];


### PR DESCRIPTION
The 'ANY' platform is a pseudo-platform and therefore cannot be used in any kind of required capability, therefore it must be filtered out when specifying the firstMatch or alwaysMatch capability sets. Attempting to use it in either of these leads to an error: "Unable to find a matching set of capabilities".

I'm not sure whether this is the _best_ approach to take here. I feel that, ideally, we should have a RequiredCapabilites class which extends DesiredCapabilities and can clone from it, but I think that also poses other issues too. Happy to take direction on this one.

Note: This will likely conflict with #695. Happy to rebase this once that issue lands.