### PR TITLE
Use clear endpoint to clear element content even in W3C mode

### DIFF
--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -62,7 +62,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
     }
 
     /**
-     * If this element is a TEXTAREA or text INPUT element, this will clear the value.
+     * Clear content editable or resettable element
      *
      * @return RemoteWebElement The current instance.
      */
@@ -72,25 +72,6 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
             DriverCommand::CLEAR_ELEMENT,
             [':id' => $this->id]
         );
-
-        if ($this->isW3cCompliant) {
-            $this->executor->execute(DriverCommand::ACTIONS, [
-                'actions' => [
-                    [
-                        'type' => 'key',
-                        'id' => 'keyboard',
-                        'actions' => [
-                            ['type' => 'keyDown', 'value' => WebDriverKeys::CONTROL],
-                            ['type' => 'keyDown', 'value' => 'a'],
-                            ['type' => 'keyUp', 'value' => WebDriverKeys::CONTROL],
-                            ['type' => 'keyUp', 'value' => 'a'],
-                            ['type' => 'keyDown', 'value' => WebDriverKeys::BACKSPACE],
-                            ['type' => 'keyUp', 'value' => WebDriverKeys::BACKSPACE],
-                        ],
-                    ],
-                ],
-            ]);
-        }
 
         return $this;
     }


### PR DESCRIPTION
This _may_ fix #704 and also resolve the issue mentioned in https://github.com/facebook/php-webdriver/pull/691#issuecomment-559883408 . 

@dunglas We are not sure why the actions sequence was there in the first place, do you remember why you add it? (Test pass even without it.)

Cc @andrewnicols @romaricdrigon - could you guys try, if it fixes the issues for you? 
`composer require facebook/webdriver:dev-w3c-clear@dev`