### PR TITLE
Use W3C command to get named cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - `WebDriverExpectedCondition::presenceOfElementLocated()` works correctly when used within `WebDriverExpectedCondition::not()`.
+- Improper behavior of Microsoft Edge when retrieving all cookies via `getCookies()` (it was causing fatal error  when there were no cookies).
 
 ## 1.7.1 - 2019-06-13
 ### Fixed

--- a/lib/Remote/DriverCommand.php
+++ b/lib/Remote/DriverCommand.php
@@ -149,6 +149,7 @@ class DriverCommand
     // W3C specific
     const ACTIONS = 'actions';
     const GET_ELEMENT_PROPERTY = 'getElementProperty';
+    const GET_NAMED_COOKIE = 'getNamedCookie';
     const TAKE_ELEMENT_SCREENSHOT = 'takeElementScreenshot';
 
     private function __construct()

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -56,6 +56,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         DriverCommand::GET_ACTIVE_ELEMENT => ['method' => 'POST', 'url' => '/session/:sessionId/element/active'],
         DriverCommand::GET_ALERT_TEXT => ['method' => 'GET', 'url' => '/session/:sessionId/alert_text'],
         DriverCommand::GET_ALL_COOKIES => ['method' => 'GET', 'url' => '/session/:sessionId/cookie'],
+        DriverCommand::GET_NAMED_COOKIE => ['method' => 'GET', 'url' => '/session/:sessionId/cookie/:name'],
         DriverCommand::GET_ALL_SESSIONS => ['method' => 'GET', 'url' => '/sessions'],
         DriverCommand::GET_AVAILABLE_LOG_TYPES => ['method' => 'GET', 'url' => '/session/:sessionId/log/types'],
         DriverCommand::GET_CURRENT_URL => ['method' => 'GET', 'url' => '/session/:sessionId/url'],

--- a/lib/WebDriverOptions.php
+++ b/lib/WebDriverOptions.php
@@ -107,6 +107,10 @@ class WebDriverOptions
                 [':name' => $name]
             );
 
+            if (!is_array($cookieArray)) { // Microsoft Edge returns null even in W3C mode => emulate proper behavior
+                throw new NoSuchCookieException('no such cookie');
+            }
+
             return Cookie::createFromArray($cookieArray);
         }
 
@@ -128,8 +132,11 @@ class WebDriverOptions
     public function getCookies()
     {
         $cookieArrays = $this->executor->execute(DriverCommand::GET_ALL_COOKIES);
-        $cookies = [];
+        if (!is_array($cookieArrays)) { // Microsoft Edge returns null if there are no cookies...
+            return [];
+        }
 
+        $cookies = [];
         foreach ($cookieArrays as $cookieArray) {
             $cookies[] = Cookie::createFromArray($cookieArray);
         }

--- a/tests/functional/WebDriverOptionsCookiesTest.php
+++ b/tests/functional/WebDriverOptionsCookiesTest.php
@@ -1,0 +1,108 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Facebook\WebDriver;
+
+use Facebook\WebDriver\Exception\NoSuchCookieException;
+
+/**
+ * @covers \Facebook\WebDriver\WebDriverOptions
+ */
+class WebDriverOptionsCookiesTest extends WebDriverTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->driver->get($this->getTestPageUrl('index.html'));
+    }
+
+    public function testShouldSetGetAndDeleteCookies()
+    {
+        $cookie1 = new Cookie('cookie1', 'cookie1Value');
+        $cookie2 = new Cookie('cookie2', 'cookie2Value');
+        $cookie3 = new Cookie('cookie3', 'cookie3Value');
+
+        // Verify initial state - no cookies are present
+        $this->assertSame([], $this->driver->manage()->getCookies());
+
+        // Add cookie1
+        $this->driver->manage()->addCookie($cookie1);
+
+        // get all cookies
+        $cookiesWithOneCookie = $this->driver->manage()->getCookies();
+        $this->assertCount(1, $cookiesWithOneCookie);
+        $this->assertContainsOnlyInstancesOf(Cookie::class, $cookiesWithOneCookie);
+        $this->assertSame('cookie1', $cookiesWithOneCookie[0]->getName());
+        $this->assertSame('cookie1Value', $cookiesWithOneCookie[0]->getValue());
+        $this->assertSame('/', $cookiesWithOneCookie[0]->getPath());
+        $this->assertSame('localhost', $cookiesWithOneCookie[0]->getDomain());
+
+        // Add cookie2
+        $this->driver->manage()->addCookie($cookie2);
+
+        // get all cookies
+        $cookiesWithTwoCookies = $this->driver->manage()->getCookies();
+
+        $this->assertCount(2, $cookiesWithTwoCookies);
+        $this->assertContainsOnlyInstancesOf(Cookie::class, $cookiesWithTwoCookies);
+
+        // normalize received cookies (their order is arbitrary)
+        $normalizedCookies = [
+            $cookiesWithTwoCookies[0]->getName() => $cookiesWithTwoCookies[0]->getValue(),
+            $cookiesWithTwoCookies[1]->getName() => $cookiesWithTwoCookies[1]->getValue(),
+        ];
+        ksort($normalizedCookies);
+        $this->assertSame(['cookie1' => 'cookie1Value', 'cookie2' => 'cookie2Value'], $normalizedCookies);
+
+        // getCookieNamed()
+        $onlyCookieOne = $this->driver->manage()->getCookieNamed('cookie1');
+        $this->assertInstanceOf(Cookie::class, $onlyCookieOne);
+        $this->assertSame('cookie1', $onlyCookieOne->getName());
+        $this->assertSame('cookie1Value', $onlyCookieOne->getValue());
+
+        // deleteCookieNamed()
+        $this->driver->manage()->deleteCookieNamed('cookie1');
+        $cookiesWithOnlySecondCookie = $this->driver->manage()->getCookies();
+        $this->assertCount(1, $cookiesWithOnlySecondCookie);
+        $this->assertSame('cookie2', $cookiesWithOnlySecondCookie[0]->getName());
+
+        // getting non-existent cookie should throw an exception in W3C mode but return null in JsonWire mode
+        if (self::isW3cProtocolBuild()) {
+            try {
+                $noSuchCookieExceptionThrown = false;
+                $this->driver->manage()->getCookieNamed('cookie1');
+            } catch (NoSuchCookieException $e) {
+                $noSuchCookieExceptionThrown = true;
+            } finally {
+                $this->assertTrue($noSuchCookieExceptionThrown, 'NoSuchCookieException was not thrown');
+            }
+        } else {
+            $this->assertNull($this->driver->manage()->getCookieNamed('cookie1'));
+        }
+
+        // deleting non-existent cookie shod not throw an error
+        $this->driver->manage()->deleteCookieNamed('cookie1');
+
+        // Add cookie3
+        $this->driver->manage()->addCookie($cookie1);
+        $this->assertCount(2, $this->driver->manage()->getCookies());
+
+        // Delete all cookies
+        $this->driver->manage()->deleteAllCookies();
+
+        $this->assertSame([], $this->driver->manage()->getCookies());
+    }
+}


### PR DESCRIPTION
In W3C mode we can use the new `get named cookie` command instead of receiving all cookies and just filtering the one with corresponding name.

Ref. #683 