### PR TITLE
Improve chrome Travis tests stability

### DIFF
--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -55,8 +55,12 @@ class WebDriverTestCase extends TestCase
 
             if ($browserName === WebDriverBrowserType::CHROME) {
                 $chromeOptions = new ChromeOptions();
-                // --no-sandbox is a workaround for Chrome crashing: https://github.com/SeleniumHQ/selenium/issues/4961
-                $chromeOptions->addArguments(['--headless', 'window-size=1024,768', '--no-sandbox']);
+                $chromeOptions->addArguments([
+                    '--headless',
+                    'window-size=1024,768',
+                    '--no-sandbox', // workaround for Chrome bug: https://github.com/SeleniumHQ/selenium/issues/4961
+                    '--disable-dev-shm-usage', // https://stackoverflow.com/q/50642308/464890
+                ]);
 
                 if (getenv('DISABLE_W3C_PROTOCOL')) {
                     $chromeOptions->setExperimentalOption('w3c', false);


### PR DESCRIPTION
For *some* reason *some* Chromedriver tests *sometimes* crash with:

> Facebook\WebDriver\Exception\UnknownErrorException: unknown error: Chrome failed to start: exited abnormally
>  (unknown error: DevToolsActivePort file doesn't exist)
>  (The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)

As per [this StackOverflow question](https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t) adding the `--disable-dev-shm-usage` flag might help. :man_shrugging: 