### PR TITLE
fixing "unknown error: path is not canonical"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - `WebDriverExpectedCondition::presenceOfElementLocated()` works correctly when used within `WebDriverExpectedCondition::not()`.
 - Improper behavior of Microsoft Edge when retrieving all cookies via `getCookies()` (it was causing fatal error  when there were no cookies).
+- Avoid "path is not canonical" error when uploading file to Chromedriver.
 
 ## 1.7.1 - 2019-06-13
 ### Fixed

--- a/lib/Remote/LocalFileDetector.php
+++ b/lib/Remote/LocalFileDetector.php
@@ -25,7 +25,7 @@ class LocalFileDetector implements FileDetector
     public function getLocalFile($file)
     {
         if (is_file($file)) {
-            return $file;
+            return realpath($file);
         }
 
         return null;

--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -40,7 +40,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
      */
     protected $id;
     /**
-     * @var UselessFileDetector
+     * @var FileDetector
      */
     protected $fileDetector;
     /**


### PR DESCRIPTION
```
Facebook\WebDriver\Exception\UnknownErrorException : unknown error: path is not canonical: /Users/oandreyev/Development/MinkFacebookWebDriver/vendor/mink/driver-testsuite/tests/Js/../../web-fixtures/file1.txt
  (Session info: chrome=79.0.3945.88)
 /Users/oandreyev/Development/MinkFacebookWebDriver/vendor/facebook/webdriver/lib/Exception/WebDriverException.php:152
 /Users/oandreyev/Development/MinkFacebookWebDriver/vendor/facebook/webdriver/lib/Remote/HttpCommandExecutor.php:390
 /Users/oandreyev/Development/MinkFacebookWebDriver/vendor/facebook/webdriver/lib/Remote/RemoteWebDriver.php:597
 /Users/oandreyev/Development/MinkFacebookWebDriver/vendor/facebook/webdriver/lib/Remote/RemoteExecuteMethod.php:40
 /Users/oandreyev/Development/MinkFacebookWebDriver/vendor/facebook/webdriver/lib/Remote/RemoteWebElement.php:369
 /Users/oandreyev/Development/MinkFacebookWebDriver/src/WebDriver.php:751
 /Users/oandreyev/Development/MinkFacebookWebDriver/src/WebDriver.php:605
 /Users/oandreyev/Development/MinkFacebookWebDriver/vendor/behat/mink/src/Element/NodeElement.php:105
 /Users/oandreyev/Development/MinkFacebookWebDriver/vendor/mink/driver-testsuite/tests/Js/ChangeEventTest.php:50
```