### PR TITLE
Remove 'any' when present in W3C platformName capabilitites

### DIFF
--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -229,6 +229,11 @@ class DesiredCapabilities implements WebDriverCapabilities
             if (array_key_exists($capabilityKey, static::$ossToW3c)) {
                 if ($capabilityKey === WebDriverCapabilityType::PLATFORM) {
                     $w3cCapabilities[static::$ossToW3c[$capabilityKey]] = mb_strtolower($capabilityValue);
+
+                    // Remove platformName if it is set to "any"
+                    if ($w3cCapabilities[static::$ossToW3c[$capabilityKey]] === 'any') {
+                        unset($w3cCapabilities[static::$ossToW3c[$capabilityKey]]);
+                    }
                 } else {
                     $w3cCapabilities[static::$ossToW3c[$capabilityKey]] = $capabilityValue;
                 }

--- a/lib/WebDriverPlatform.php
+++ b/lib/WebDriverPlatform.php
@@ -23,6 +23,7 @@ namespace Facebook\WebDriver;
 class WebDriverPlatform
 {
     const ANDROID = 'ANDROID';
+    /** @deprecated */
     const ANY = 'ANY';
     const LINUX = 'LINUX';
     const MAC = 'MAC';

--- a/tests/unit/Remote/DesiredCapabilitiesTest.php
+++ b/tests/unit/Remote/DesiredCapabilitiesTest.php
@@ -187,7 +187,7 @@ class DesiredCapabilitiesTest extends TestCase
                 ]),
                 [],
             ],
-            'already W3C capabilitites' => [
+            'already W3C capabilities' => [
                 new DesiredCapabilities([
                     'pageLoadStrategy' => 'eager',
                     'strictFileInteractability' => false,
@@ -196,6 +196,12 @@ class DesiredCapabilitiesTest extends TestCase
                     'pageLoadStrategy' => 'eager',
                     'strictFileInteractability' => false,
                 ],
+            ],
+            '"ANY" platform should be completely removed' => [
+                new DesiredCapabilities([
+                    WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
+                ]),
+                [],
             ],
             'custom vendor extension' => [
                 new DesiredCapabilities([


### PR DESCRIPTION
"ANY" is no longer a meaningful value for platformName in W3C mode - see [specs](https://w3c.github.io/webdriver/#x7-2-processing-capabilities).

Moreover it causes geckodriver to reject creating new session when present:
> SessionNotCreatedException: Unable to find a matching set of capabilities

May replace #703